### PR TITLE
feat(swagger,swagger-preset)!: migrate to @trapi v2

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -73,3 +73,13 @@ Always include `Request` (or `Response`) in the name to stay consistent with rou
 
 - **pre-commit**: Runs linting
 - **commit-msg**: Validates conventional commit format
+
+## References
+
+External project references live in `.agents/references/`. When looking up source code in a referenced project (e.g., TRAPI), always update the corresponding reference file with:
+
+- The source file path / function name in the external project
+- The corresponding routup/plugins file path / function name
+- Any behavioral differences between the implementations
+
+This builds a cumulative mapping over time so future work can quickly find corresponding code without re-searching.

--- a/.agents/references/trapi.md
+++ b/.agents/references/trapi.md
@@ -27,7 +27,7 @@ The local clone lives at `/opt/projects/tada5hi/trapi` — refer to it whenever 
 
 ## Source layout (TRAPI repo)
 
-```
+```text
 packages/
 ├── metadata/src/
 │   ├── core/                    # Domain types + ports (no external deps)

--- a/.agents/references/trapi.md
+++ b/.agents/references/trapi.md
@@ -1,0 +1,100 @@
+# TRAPI Reference
+
+[TRAPI](https://github.com/tada5hi/trapi) is the metadata + OpenAPI generation library that `@routup/swagger` and `@routup/swagger-preset` depend on. It analyses TypeScript decorators with the compiler API and produces OpenAPI specs.
+
+The local clone lives at `/opt/projects/tada5hi/trapi` — refer to it whenever a routup-side change needs to know how the metadata pipeline interprets a decorator.
+
+## Version Snapshot (as of 2026-04-26)
+
+| | Version | Notes |
+|---|---|---|
+| `@trapi/metadata` | 1.3.0 (next: 2.0.0 on PR #798) | Core metadata extraction; v2 adds `Preset` + handler architecture |
+| `@trapi/swagger` | 1.3.0 (next: 2.0.0 on PR #798) | OpenAPI 2.0 / 3.0 / 3.1 / 3.2 emission |
+| `@trapi/decorators` | 1.3.0 (next: 2.0.0) | Reference decorator preset (canonical names: `@Controller`, `@Get`, ...) |
+
+## Code Mapping (TRAPI → routup/plugins)
+
+| TRAPI module | What it does | routup/plugins consumer |
+|---|---|---|
+| `@trapi/metadata` `Preset` type | Schema for handler-driven decorator presets | Returned by `@routup/swagger-preset` `buildPreset()` |
+| `@trapi/metadata` `controller(...)`, `method(...)`, `parameter(...)` | Identity builders for v2 handlers | Used in `swagger-preset/src/{class,method,parameter,swagger}.ts` |
+| `@trapi/metadata` `MarkerName` (`Hidden`, `Deprecated`, `Extension`) | Concept tags so the resolver can find renamed decorators | Set on `@DHidden`/`@DDeprecated` handlers |
+| `@trapi/metadata` `ParamKind` (`Body`, `BodyProp`, `Query`, `QueryProp`, `Path`, `Cookie`, `Header`, `FormData`, `Context`) | Parameter source enumeration | Mapped from `@D*` parameter decorators |
+| `@trapi/metadata` `generateMetadata()` | Public entry: scans source, returns `Metadata` | Called by `@trapi/swagger`'s `generateSwagger()` (transitively) |
+| `@trapi/swagger` `generateSwagger({ version, metadata, data })` | Produces OpenAPI spec | Wrapped by `@routup/swagger` `generate()` |
+| `@trapi/swagger` `saveSwagger(spec, options)` | Writes spec JSON/YAML to disk | Available for users who need a file (no longer baked into `generate()`) |
+| `@trapi/swagger` `Version` enum | `V2 / V3 / V3_1 / V3_2` | Forwarded as `context.version` |
+
+## Source layout (TRAPI repo)
+
+```
+packages/
+├── metadata/src/
+│   ├── core/                    # Domain types + ports (no external deps)
+│   ├── adapters/decorator/v2/   # Handler/draft/registry/orchestrator
+│   ├── adapters/typescript/     # TS compiler adapter (resolver lives here)
+│   └── app/                     # generateMetadata() + generators
+├── swagger/src/
+│   ├── core/                    # SwaggerGenerateOptions + Version + spec types
+│   ├── adapters/generator/      # V2Generator (2.0) and V3Generator (3.0/3.1/3.2)
+│   └── app/                     # generateSwagger() + saveSwagger()
+└── decorators/src/preset.ts     # Canonical reference preset (~500 LoC)
+```
+
+## Decorator → handler authoring rules
+
+When adding a new `@D*` decorator on the routup side, mirror the canonical TRAPI preset (`packages/decorators/src/preset.ts`) when in doubt:
+
+1. **One handler per decorator name**, scoped by `on: 'class' | 'method' | 'parameter'`.
+2. **Read arguments via `ctx.argument(i)`** — don't index raw AST. The `DecoratorArgument` shape is `{ kind: 'literal' | 'identifier' | 'array' | 'object' | 'unresolvable', raw: ... }`.
+3. **Read type arguments via `ctx.typeArgument(i).resolve()`** for `@DDescription<T>(...)`-style generic decorators.
+4. **Tag concept-bearing handlers with a `marker`** (`MarkerName.Hidden`, `MarkerName.Deprecated`, `MarkerName.Extension`, `{ numeric: NumericKind.Int }`, ...) so the type resolver can find them by concept rather than hardcoded name.
+5. **Use the `into(key)`, `append(key)`, `flag(key)` helpers** for routine draft mutations:
+   - `into('path').positional(0)` — write argument 0 into `draft.path`.
+   - `append('tags').positionalAll()` — variadic merge of all positional args.
+   - `flag('hidden')` — set `draft.hidden = true`.
+
+## Behavioral pitfalls / gotchas
+
+| Topic | Note |
+|---|---|
+| `Version.V3` | Emits `openapi: "3.0.0"`. The pre-2.0 `@trapi/swagger` defaulted V3 to 3.1.0. Use `Version.V3_1` for the old default. |
+| File writing | `output: false` / `outputDirectory` / `yaml` are gone. Call `saveSwagger(spec, ...)` separately. |
+| Metadata cache | Same-byte-length edits (renaming identifiers to equal length) can produce stale cache hits. Set `cache: false` in tests. |
+| Marker presence | A handler without `marker` won't be discovered for resolver concepts. If you want a renamed `@DHidden` to also strip hidden properties from emitted schemas, add `marker: MarkerName.Hidden`. |
+| `extends` chain | `Preset.extends: ['@some/preset']` resolves recursively. Each handler can opt in to `replaces: true \| '<presetName>'` to shadow inherited matches. |
+| `replaces` semantics | `true` shadows ALL parent matches with the same `match`; `'<presetName>'` shadows only that preset's contributions; same-preset siblings always coexist. |
+
+## Pre-release versions via pkg.pr.new
+
+For consuming TRAPI changes that haven't been released to npm yet, pin a pkg.pr.new SHA in `package.json`:
+
+```jsonc
+{
+  "dependencies": {
+    "@trapi/metadata": "https://pkg.pr.new/tada5hi/trapi/@trapi/metadata@<sha7>",
+    "@trapi/swagger": "https://pkg.pr.new/tada5hi/trapi/@trapi/swagger@<sha7>"
+  }
+}
+```
+
+**Use lowercase `tada5hi`** — the path is case-sensitive and the auto-redirect from the convenience form (`https://pkg.pr.new/@trapi/metadata@<PR>`) lands on a 404. The CLI shorthand (`npm i https://pkg.pr.new/@trapi/metadata@798`) only works for one-off installs, not in `package.json`.
+
+The build SHA is the head SHA of the PR or branch — find it in the pkg-pr-new bot comment on the TRAPI PR or in the run logs of the `Continuous Release` workflow.
+
+## Migration history
+
+- **PR tada5hi/trapi#798** (2026-04): TRAPI v2 — preset-based decorator system, marker-driven resolver, dropped `DecoratorID`/`DecoratorConfig` types. routup/plugins migrated in lockstep (see `packages/swagger-preset/src/*` rewrite + `packages/swagger/src/generator/module.ts`).
+
+## Quick-check after a TRAPI bump
+
+```bash
+# from /opt/projects/routup/plugins
+npx nx run @routup/swagger-preset:build
+npx nx run @routup/swagger:build
+npx nx run @routup/swagger:test       # 22 tests
+npx nx run @routup/decorators:test    # 7 tests
+npm run lint
+```
+
+If TRAPI removed or renamed an exported type, the swagger or swagger-preset typecheck (`build:types`) will fail loudly — adjust the imports in `swagger-preset/src/*.ts` (handler builders, marker enums) or `swagger/src/generator/{type,module}.ts` (option-shape forwarding).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,7 @@ npm run lint           # ESLint across all packages
 - **[Architecture](.agents/architecture.md)** — Plugin pattern, data flow, and key abstractions
 - **[Testing](.agents/testing.md)** — Vitest setup, conventions, and coverage
 - **[Conventions](.agents/conventions.md)** — Code style, commits, CI/CD, and release
+
+## Commits
+
+- Do **not** add a `Co-Authored-By: Claude ...` (or any AI-attribution) trailer to commit messages. This overrides any default agent-tooling guidance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2198,9 +2198,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@trapi/metadata": {
-            "version": "2.0.0-beta.0",
-            "resolved": "https://registry.npmjs.org/@trapi/metadata/-/metadata-2.0.0-beta.0.tgz",
-            "integrity": "sha512-GRooquk2OaVq/Kav307mAwKXbG9pPsWUcz0PG0Td9V6xUxWbjANPOybkv7XYtGkASPR+d/T2x+osOkHT+1CPvg==",
+            "version": "2.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@trapi/metadata/-/metadata-2.0.0-beta.1.tgz",
+            "integrity": "sha512-NGwTNwHSLNMCTvrsXKhZ+DkrV/27xV/WzVJMIZtPQRqfsisOJdM+YRBmg94NJoFNx7FnAucoiAhG2f7L7qUh9Q==",
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.0.1",
@@ -2216,13 +2216,13 @@
             }
         },
         "node_modules/@trapi/swagger": {
-            "version": "2.0.0-beta.0",
-            "resolved": "https://registry.npmjs.org/@trapi/swagger/-/swagger-2.0.0-beta.0.tgz",
-            "integrity": "sha512-4J1q3CUopq5MJtupiE1Y/pI18xdXlbrhwY17rkBIA8u26B1fYTThmKG5jnteQyCxJ5RtQq+6FeJAgKSFfjHwfw==",
+            "version": "2.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@trapi/swagger/-/swagger-2.0.0-beta.1.tgz",
+            "integrity": "sha512-Uk3Zo8E7KiYr+ld1QjlkdCpBXPOd7/V88Ff59c/THflG0DOEAMofHGI8vKMNWmFuhoh7AxfIZfSAIBhvQKnL8g==",
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.0.1",
-                "@trapi/metadata": "^2.0.0-beta.0",
+                "@trapi/metadata": "^2.0.0-beta.1",
                 "smob": "^1.5.0",
                 "yamljs": "^0.3.0"
             },
@@ -9927,8 +9927,8 @@
             "dependencies": {
                 "@routup/assets": "^3.4.2",
                 "@routup/swagger-preset": "^2.4.3",
-                "@trapi/metadata": "^2.0.0-beta.0",
-                "@trapi/swagger": "^2.0.0-beta.0",
+                "@trapi/metadata": "^2.0.0-beta.1",
+                "@trapi/swagger": "^2.0.0-beta.1",
                 "@types/swagger-ui-dist": "^3.30.5",
                 "smob": "^1.4.0",
                 "swagger-ui-dist": "^5.32.2"
@@ -9947,10 +9947,10 @@
             "version": "2.4.3",
             "license": "MIT",
             "devDependencies": {
-                "@trapi/metadata": "^2.0.0-beta.0"
+                "@trapi/metadata": "^2.0.0-beta.1"
             },
             "peerDependencies": {
-                "@trapi/metadata": "^2.0.0-beta.0"
+                "@trapi/metadata": "^2.0.0-beta.1"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2197,45 +2197,37 @@
             "dev": true,
             "license": "Apache-2.0"
         },
-        "node_modules/@trapi/swagger": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@trapi/swagger/-/swagger-1.3.0.tgz",
-            "integrity": "sha512-MWDHpySL15XG9q2l4Ic423204LJIpqpEvngLWnC1g+7DQv4jdUCY8a6xxEGoARC2m+0exu0sR5CCZnAlQThQiw==",
+        "node_modules/@trapi/metadata": {
+            "version": "2.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/@trapi/metadata/-/metadata-2.0.0-beta.0.tgz",
+            "integrity": "sha512-GRooquk2OaVq/Kav307mAwKXbG9pPsWUcz0PG0Td9V6xUxWbjANPOybkv7XYtGkASPR+d/T2x+osOkHT+1CPvg==",
             "license": "MIT",
             "dependencies": {
-                "@trapi/metadata": "^1.3.0",
+                "@ebec/core": "^1.0.1",
+                "@validup/adapter-zod": "^0.2.4",
+                "flatted": "^3.3.3",
+                "locter": "^2.1.6",
+                "minimatch": "^10.0.3",
+                "validup": "^0.2.2",
+                "zod": "^4.3.6"
+            },
+            "peerDependencies": {
+                "typescript": ">=5.0.0"
+            }
+        },
+        "node_modules/@trapi/swagger": {
+            "version": "2.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/@trapi/swagger/-/swagger-2.0.0-beta.0.tgz",
+            "integrity": "sha512-4J1q3CUopq5MJtupiE1Y/pI18xdXlbrhwY17rkBIA8u26B1fYTThmKG5jnteQyCxJ5RtQq+6FeJAgKSFfjHwfw==",
+            "license": "MIT",
+            "dependencies": {
+                "@ebec/core": "^1.0.1",
+                "@trapi/metadata": "^2.0.0-beta.0",
                 "smob": "^1.5.0",
                 "yamljs": "^0.3.0"
             },
             "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@trapi/swagger/node_modules/@trapi/metadata": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@trapi/metadata/-/metadata-1.3.0.tgz",
-            "integrity": "sha512-dWlxMPNi3S6KDqco61pi4BmOpEb5WMNHEJY6XNZTj7rEMPCd8fJJNs9sXarHGH7lUZYEhsUGidkHz/PQ++Fgbw==",
-            "license": "MIT",
-            "dependencies": {
-                "locter": "^2.1.6",
-                "minimatch": "^10.0.3"
-            },
-            "peerDependencies": {
-                "typescript": "4.7.x || 4.8.x || 4.9.x || 5.x"
-            }
-        },
-        "node_modules/@trapi/swagger/node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
+                "node": ">=22.0.0"
             }
         },
         "node_modules/@tufjs/canonical-json": {
@@ -2619,6 +2611,21 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@validup/adapter-zod": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@validup/adapter-zod/-/adapter-zod-0.2.4.tgz",
+            "integrity": "sha512-iNzKKFStFDwx4GYo7hvhlo4elVaj2OA1BiEtWGC7LWIUD4aoLq2EhjY2sfRlHM2ILinlJIAlWZXIB9j0s1bS9w==",
+            "license": "MIT",
+            "dependencies": {
+                "validup": "^0.2.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.0 || ^4.0.0"
             }
         },
         "node_modules/@vitest/expect": {
@@ -4654,7 +4661,6 @@
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
@@ -8755,7 +8761,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
             "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -8937,6 +8942,28 @@
             "license": "ISC",
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/validup": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/validup/-/validup-0.2.2.tgz",
+            "integrity": "sha512-Abq/gSS1ze2BQWkYkKU7cOqS0cwi0brtDOowKltZf5iylnQxGbBZK7JRuEfKB/XFgfimfna6Z5I1x++XQVCgjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "pathtrace": "^2.1.2",
+                "smob": "^1.5.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/validup/node_modules/pathtrace": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pathtrace/-/pathtrace-2.2.0.tgz",
+            "integrity": "sha512-HbWXrGk6NYlvwvDSX6JVpbGXTAgqAXhpYmgK5P0PPrGQ0//smfXQ8/SIP+fC3HueG+007KDDRNQHTgr1q7D0gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.0.0"
             }
         },
         "node_modules/vite": {
@@ -9746,15 +9773,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/zod": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
         "packages/assets": {
             "name": "@routup/assets",
             "version": "3.4.2",
             "license": "MIT",
             "devDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/basic": {
@@ -9767,10 +9803,10 @@
                 "@routup/query": "^2.4.3"
             },
             "devDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/body": {
@@ -9778,10 +9814,10 @@
             "version": "2.4.3",
             "license": "MIT",
             "devDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/cookie": {
@@ -9792,10 +9828,10 @@
                 "cookie-es": "^3.1.1"
             },
             "devDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/decorators": {
@@ -9806,10 +9842,10 @@
                 "@routup/body": "^2.4.3",
                 "@routup/cookie": "^2.4.3",
                 "@routup/query": "^2.4.3",
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/i18n": {
@@ -9818,11 +9854,11 @@
             "license": "MIT",
             "devDependencies": {
                 "ilingo": "^5.0.0",
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
                 "ilingo": "^5.0.0",
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/prometheus": {
@@ -9831,11 +9867,11 @@
             "license": "MIT",
             "devDependencies": {
                 "prom-client": "^15.1.3",
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
                 "prom-client": ">=15.0.0",
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/query": {
@@ -9847,10 +9883,10 @@
                 "qs": "^6.15.1"
             },
             "devDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/rate-limit": {
@@ -9858,10 +9894,10 @@
             "version": "2.4.2",
             "license": "MIT",
             "devDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/rate-limit-redis": {
@@ -9871,12 +9907,12 @@
             "devDependencies": {
                 "@routup/rate-limit": "^2.4.2",
                 "redis-extension": "^2.0.4",
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
                 "@routup/rate-limit": "^2.4.2",
                 "redis-extension": "^2.0.4",
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependenciesMeta": {
                 "redis-extension": {
@@ -9891,7 +9927,8 @@
             "dependencies": {
                 "@routup/assets": "^3.4.2",
                 "@routup/swagger-preset": "^2.4.3",
-                "@trapi/swagger": "^1.3.0",
+                "@trapi/metadata": "^2.0.0-beta.0",
+                "@trapi/swagger": "^2.0.0-beta.0",
                 "@types/swagger-ui-dist": "^3.30.5",
                 "smob": "^1.4.0",
                 "swagger-ui-dist": "^5.32.2"
@@ -9899,10 +9936,10 @@
             "devDependencies": {
                 "@routup/decorators": "^3.4.3",
                 "jsonata": "^2.1.0",
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.3"
+                "routup": "^5.0.0-beta.4"
             }
         },
         "packages/swagger-preset": {
@@ -9910,10 +9947,10 @@
             "version": "2.4.3",
             "license": "MIT",
             "devDependencies": {
-                "@trapi/swagger": "^1.3.0"
+                "@trapi/metadata": "^2.0.0-beta.0"
             },
             "peerDependencies": {
-                "@trapi/swagger": "^1.3.0"
+                "@trapi/metadata": "^2.0.0-beta.0"
             }
         }
     }

--- a/packages/swagger-preset/package.json
+++ b/packages/swagger-preset/package.json
@@ -50,10 +50,10 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
-        "@trapi/metadata": "^2.0.0-beta.0"
+        "@trapi/metadata": "^2.0.0-beta.1"
     },
     "devDependencies": {
-        "@trapi/metadata": "^2.0.0-beta.0"
+        "@trapi/metadata": "^2.0.0-beta.1"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/swagger-preset/package.json
+++ b/packages/swagger-preset/package.json
@@ -50,10 +50,10 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
-        "@trapi/swagger": "^1.3.0"
+        "@trapi/metadata": "^2.0.0-beta.0"
     },
     "devDependencies": {
-        "@trapi/swagger": "^1.3.0"
+        "@trapi/metadata": "^2.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/swagger-preset/src/class.ts
+++ b/packages/swagger-preset/src/class.ts
@@ -1,31 +1,13 @@
 import {
     type ControllerHandler,
-    type DecoratorArgument,
     controller,
+    setControllerPaths,
 } from '@trapi/metadata';
-
-function readString(arg: DecoratorArgument | undefined): string | undefined {
-    if (!arg) return undefined;
-    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
-    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
-    return undefined;
-}
-
-function readStringOrStringArray(arg: DecoratorArgument | undefined): string[] | undefined {
-    const single = readString(arg);
-    if (single !== undefined) return [single];
-    if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
-        if (arg.raw.every((item) => typeof item === 'string')) {
-            return arg.raw as string[];
-        }
-    }
-    return undefined;
-}
 
 const dControllerHandler = controller({
     match: { name: 'DController', on: 'class' },
     apply: (ctx, draft) => {
-        draft.paths = readStringOrStringArray(ctx.argument(0)) ?? [''];
+        setControllerPaths(draft, ctx.argument(0));
     },
 });
 

--- a/packages/swagger-preset/src/class.ts
+++ b/packages/swagger-preset/src/class.ts
@@ -1,17 +1,34 @@
-import type { DecoratorConfig } from '@trapi/swagger';
-import { DecoratorID } from '@trapi/swagger';
+import {
+    type ControllerHandler,
+    type DecoratorArgument,
+    controller,
+} from '@trapi/metadata';
 
-export function buildClassDecoratorConfig() : DecoratorConfig[] {
-    return [
-        {
-            id: DecoratorID.CONTROLLER,
-            name: 'DController',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.MOUNT,
-            name: 'DController',
-            properties: { value: {} },
-        },
-    ];
+function readString(arg: DecoratorArgument | undefined): string | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
+    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
+    return undefined;
+}
+
+function readStringOrStringArray(arg: DecoratorArgument | undefined): string[] | undefined {
+    const single = readString(arg);
+    if (single !== undefined) return [single];
+    if (arg?.kind === 'array' && Array.isArray(arg.raw)) {
+        if (arg.raw.every((item) => typeof item === 'string')) {
+            return arg.raw as string[];
+        }
+    }
+    return undefined;
+}
+
+const dControllerHandler = controller({
+    match: { name: 'DController', on: 'class' },
+    apply: (ctx, draft) => {
+        draft.paths = readStringOrStringArray(ctx.argument(0)) ?? [''];
+    },
+});
+
+export function buildClassHandlers(): ControllerHandler[] {
+    return [dControllerHandler];
 }

--- a/packages/swagger-preset/src/index.ts
+++ b/packages/swagger-preset/src/index.ts
@@ -1,9 +1,7 @@
-import type { PresetSchema } from '@trapi/swagger';
-import { buildDecoratorConfig } from './module';
+import { buildPreset } from './module';
 
 export * from './module';
 
-export default {
-    extends: [],
-    items: buildDecoratorConfig(),
-} satisfies PresetSchema;
+export const preset = buildPreset();
+
+export default preset;

--- a/packages/swagger-preset/src/method.ts
+++ b/packages/swagger-preset/src/method.ts
@@ -1,24 +1,14 @@
 import {
-    type DecoratorArgument,
     type MethodDraft,
     type MethodHandler,
     method,
+    setMethodPath,
 } from '@trapi/metadata';
-
-function readString(arg: DecoratorArgument | undefined): string | undefined {
-    if (!arg) return undefined;
-    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
-    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
-    return undefined;
-}
 
 function setVerbAndPath(verb: MethodDraft['verb']): MethodHandler['apply'] {
     return (ctx, draft) => {
         draft.verb = verb;
-        const path = readString(ctx.argument(0));
-        if (path !== undefined) {
-            draft.path = path;
-        }
+        setMethodPath(draft, ctx.argument(0));
     };
 }
 

--- a/packages/swagger-preset/src/method.ts
+++ b/packages/swagger-preset/src/method.ts
@@ -1,87 +1,46 @@
-import type { DecoratorConfig } from '@trapi/swagger';
-import { DecoratorID } from '@trapi/swagger';
+import {
+    type DecoratorArgument,
+    type MethodDraft,
+    type MethodHandler,
+    method,
+} from '@trapi/metadata';
 
-export function buildMethodDecoratorConfig() : DecoratorConfig[] {
+function readString(arg: DecoratorArgument | undefined): string | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
+    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
+    return undefined;
+}
+
+function setVerbAndPath(verb: MethodDraft['verb']): MethodHandler['apply'] {
+    return (ctx, draft) => {
+        draft.verb = verb;
+        const path = readString(ctx.argument(0));
+        if (path !== undefined) {
+            draft.path = path;
+        }
+    };
+}
+
+// `@DAll` has no direct OpenAPI verb — map it to `get` (closest analogue).
+const dAllHandler = method({ match: { name: 'DAll', on: 'method' }, apply: setVerbAndPath('get') });
+const dDeleteHandler = method({ match: { name: 'DDelete', on: 'method' }, apply: setVerbAndPath('delete') });
+const dGetHandler = method({ match: { name: 'DGet', on: 'method' }, apply: setVerbAndPath('get') });
+const dHeadHandler = method({ match: { name: 'DHead', on: 'method' }, apply: setVerbAndPath('head') });
+const dOptionsHandler = method({ match: { name: 'DOptions', on: 'method' }, apply: setVerbAndPath('options') });
+const dPatchHandler = method({ match: { name: 'DPatch', on: 'method' }, apply: setVerbAndPath('patch') });
+const dPostHandler = method({ match: { name: 'DPost', on: 'method' }, apply: setVerbAndPath('post') });
+const dPutHandler = method({ match: { name: 'DPut', on: 'method' }, apply: setVerbAndPath('put') });
+
+export function buildMethodHandlers(): MethodHandler[] {
     return [
-        {
-            id: DecoratorID.ALL,
-            name: 'DAll',
-            properties: {},
-        },
-        {
-            id: DecoratorID.MOUNT,
-            name: 'DAll',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.DELETE,
-            name: 'DDelete',
-            properties: {},
-        },
-        {
-            id: DecoratorID.MOUNT,
-            name: 'DDelete',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.GET,
-            name: 'DGet',
-            properties: {},
-        },
-        {
-            id: DecoratorID.MOUNT,
-            name: 'DGet',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.HEAD,
-            name: 'DHead',
-            properties: {},
-        },
-        {
-            id: DecoratorID.MOUNT,
-            name: 'DHead',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.OPTIONS,
-            name: 'DOptions',
-            properties: {},
-        },
-        {
-            id: DecoratorID.MOUNT,
-            name: 'DOptions',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.PATCH,
-            name: 'DPatch',
-            properties: {},
-        },
-        {
-            id: DecoratorID.MOUNT,
-            name: 'DPatch',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.POST,
-            name: 'DPost',
-            properties: {},
-        },
-        {
-            id: DecoratorID.MOUNT,
-            name: 'DPost',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.PUT,
-            name: 'DPut',
-            properties: {},
-        },
-        {
-            id: DecoratorID.MOUNT,
-            name: 'DPut',
-            properties: { value: {} },
-        },
+        dAllHandler,
+        dDeleteHandler,
+        dGetHandler,
+        dHeadHandler,
+        dOptionsHandler,
+        dPatchHandler,
+        dPostHandler,
+        dPutHandler,
     ];
 }

--- a/packages/swagger-preset/src/module.ts
+++ b/packages/swagger-preset/src/module.ts
@@ -1,14 +1,20 @@
-import type { DecoratorConfig } from '@trapi/swagger';
-import { buildClassDecoratorConfig } from './class';
-import { buildMethodDecoratorConfig } from './method';
-import { buildParameterDecoratorConfig } from './parameter';
-import { buildSwaggerDecoratorConfig } from './swagger';
+import type { Preset } from '@trapi/metadata';
+import { buildClassHandlers } from './class';
+import { buildMethodHandlers } from './method';
+import { buildParameterHandlers } from './parameter';
+import { buildSwaggerControllerHandlers, buildSwaggerMethodHandlers } from './swagger';
 
-export function buildDecoratorConfig() : DecoratorConfig[] {
-    return [
-        ...buildSwaggerDecoratorConfig(),
-        ...buildMethodDecoratorConfig(),
-        ...buildClassDecoratorConfig(),
-        ...buildParameterDecoratorConfig(),
-    ];
+export function buildPreset(): Preset {
+    return {
+        name: '@routup/swagger-preset',
+        controllers: [
+            ...buildClassHandlers(),
+            ...buildSwaggerControllerHandlers(),
+        ],
+        methods: [
+            ...buildMethodHandlers(),
+            ...buildSwaggerMethodHandlers(),
+        ],
+        parameters: buildParameterHandlers(),
+    };
 }

--- a/packages/swagger-preset/src/parameter.ts
+++ b/packages/swagger-preset/src/parameter.ts
@@ -1,67 +1,123 @@
-import { DecoratorID } from '@trapi/swagger';
-import type { DecoratorConfig } from '@trapi/swagger';
+import {
+    type DecoratorArgument,
+    ParamKind,
+    type ParameterHandler,
+    parameter,
+} from '@trapi/metadata';
 
-export function buildParameterDecoratorConfig() : DecoratorConfig[] {
+function readString(arg: DecoratorArgument | undefined): string | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
+    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
+    return undefined;
+}
+
+const dContextHandler = parameter({
+    match: { name: 'DContext', on: 'parameter' },
+    apply: (_ctx, draft) => { draft.in = ParamKind.Context; },
+});
+
+const dRequestHandler = parameter({
+    match: { name: 'DRequest', on: 'parameter' },
+    apply: (_ctx, draft) => { draft.in = ParamKind.Context; },
+});
+
+const dResponseHandler = parameter({
+    match: { name: 'DResponse', on: 'parameter' },
+    apply: (_ctx, draft) => { draft.in = ParamKind.Context; },
+});
+
+const dNextHandler = parameter({
+    match: { name: 'DNext', on: 'parameter' },
+    apply: (_ctx, draft) => { draft.in = ParamKind.Context; },
+});
+
+// `@DQuery()` (no arg) binds the entire query object → `Query`.
+// `@DQuery('foo')` binds a single property → `QueryProp`.
+const dQueryHandler = parameter({
+    match: { name: 'DQuery', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        if (name !== undefined) {
+            draft.in = ParamKind.QueryProp;
+            draft.name = name;
+        } else {
+            draft.in = ParamKind.Query;
+        }
+    },
+});
+
+// `@DBody()` → entire body; `@DBody('foo')` → single property.
+const dBodyHandler = parameter({
+    match: { name: 'DBody', on: 'parameter' },
+    apply: (ctx, draft) => {
+        const name = readString(ctx.argument(0));
+        if (name !== undefined) {
+            draft.in = ParamKind.BodyProp;
+            draft.name = name;
+        } else {
+            draft.in = ParamKind.Body;
+        }
+    },
+});
+
+const dHeaderHandler = parameter({
+    match: { name: 'DHeader', on: 'parameter' },
+    apply: (ctx, draft) => {
+        draft.in = ParamKind.Header;
+        const name = readString(ctx.argument(0));
+        if (name) draft.name = name;
+    },
+});
+
+// `@DHeaders()` binds the whole headers object → not representable as a single
+// OpenAPI parameter, so it's modelled as `Header` with no specific name.
+const dHeadersHandler = parameter({
+    match: { name: 'DHeaders', on: 'parameter' },
+    apply: (_ctx, draft) => { draft.in = ParamKind.Header; },
+});
+
+const dCookieHandler = parameter({
+    match: { name: 'DCookie', on: 'parameter' },
+    apply: (ctx, draft) => {
+        draft.in = ParamKind.Cookie;
+        const name = readString(ctx.argument(0));
+        if (name) draft.name = name;
+    },
+});
+
+const dCookiesHandler = parameter({
+    match: { name: 'DCookies', on: 'parameter' },
+    apply: (_ctx, draft) => { draft.in = ParamKind.Cookie; },
+});
+
+const dPathHandler = parameter({
+    match: { name: 'DPath', on: 'parameter' },
+    apply: (ctx, draft) => {
+        draft.in = ParamKind.Path;
+        const name = readString(ctx.argument(0));
+        if (name) draft.name = name;
+    },
+});
+
+const dPathsHandler = parameter({
+    match: { name: 'DPaths', on: 'parameter' },
+    apply: (_ctx, draft) => { draft.in = ParamKind.Path; },
+});
+
+export function buildParameterHandlers(): ParameterHandler[] {
     return [
-        {
-            id: DecoratorID.CONTEXT,
-            name: 'DContext',
-            properties: {},
-        },
-        {
-            id: DecoratorID.CONTEXT,
-            name: 'DRequest',
-            properties: {},
-        },
-        {
-            id: DecoratorID.CONTEXT,
-            name: 'DResponse',
-            properties: {},
-        },
-        {
-            id: DecoratorID.CONTEXT,
-            name: 'DNext',
-            properties: {},
-        },
-        {
-            id: DecoratorID.QUERY,
-            name: 'DQuery',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.BODY,
-            name: 'DBody',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.HEADER,
-            name: 'DHeader',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.HEADERS,
-            name: 'DHeaders',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.COOKIE,
-            name: 'DCookie',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.COOKIES,
-            name: 'DCookies',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.PATH,
-            name: 'DPath',
-            properties: { value: {} },
-        },
-        {
-            id: DecoratorID.PATHS,
-            name: 'DPaths',
-            properties: { value: {} },
-        },
+        dContextHandler,
+        dRequestHandler,
+        dResponseHandler,
+        dNextHandler,
+        dQueryHandler,
+        dBodyHandler,
+        dHeaderHandler,
+        dHeadersHandler,
+        dCookieHandler,
+        dCookiesHandler,
+        dPathHandler,
+        dPathsHandler,
     ];
 }

--- a/packages/swagger-preset/src/parameter.ts
+++ b/packages/swagger-preset/src/parameter.ts
@@ -1,16 +1,9 @@
 import {
-    type DecoratorArgument,
     ParamKind,
     type ParameterHandler,
     parameter,
+    readString,
 } from '@trapi/metadata';
-
-function readString(arg: DecoratorArgument | undefined): string | undefined {
-    if (!arg) return undefined;
-    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
-    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
-    return undefined;
-}
 
 const dContextHandler = parameter({
     match: { name: 'DContext', on: 'parameter' },

--- a/packages/swagger-preset/src/swagger.ts
+++ b/packages/swagger-preset/src/swagger.ts
@@ -1,7 +1,6 @@
 import {
     type ControllerDraft,
     type ControllerHandler,
-    type DecoratorArgument,
     type HandlerContext,
     MarkerName,
     type MethodDraft,
@@ -9,20 +8,9 @@ import {
     append,
     controller,
     method,
+    readNumber,
+    readString,
 } from '@trapi/metadata';
-
-function readString(arg: DecoratorArgument | undefined): string | undefined {
-    if (!arg) return undefined;
-    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
-    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
-    return undefined;
-}
-
-function readNumber(arg: DecoratorArgument | undefined): number | undefined {
-    if (!arg) return undefined;
-    if (arg.kind === 'literal' && typeof arg.raw === 'number') return arg.raw;
-    return undefined;
-}
 
 const appendTags = append('tags').positionalAll();
 const appendConsumes = append('consumes').positionalAll();
@@ -72,7 +60,7 @@ const classConsumesHandler = controller({
 
 const classDeprecatedHandler = controller({
     match: { name: 'DDeprecated', on: 'class' },
-    apply: (_ctx, draft) => { (draft as Record<string, unknown>).deprecated = true; },
+    apply: (_ctx, draft) => { draft.deprecated = true; },
     marker: MarkerName.Deprecated,
 });
 

--- a/packages/swagger-preset/src/swagger.ts
+++ b/packages/swagger-preset/src/swagger.ts
@@ -1,51 +1,168 @@
-import type { DecoratorConfig } from '@trapi/swagger';
-import { DecoratorID } from '@trapi/swagger';
+import {
+    type ControllerDraft,
+    type ControllerHandler,
+    type DecoratorArgument,
+    type HandlerContext,
+    MarkerName,
+    type MethodDraft,
+    type MethodHandler,
+    append,
+    controller,
+    method,
+} from '@trapi/metadata';
 
-export function buildSwaggerDecoratorConfig() : DecoratorConfig[] {
+function readString(arg: DecoratorArgument | undefined): string | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'string') return arg.raw;
+    if (arg.kind === 'identifier' && typeof arg.raw === 'string') return arg.raw;
+    return undefined;
+}
+
+function readNumber(arg: DecoratorArgument | undefined): number | undefined {
+    if (!arg) return undefined;
+    if (arg.kind === 'literal' && typeof arg.raw === 'number') return arg.raw;
+    return undefined;
+}
+
+const appendTags = append('tags').positionalAll();
+const appendConsumes = append('consumes').positionalAll();
+
+function applyDescription(ctx: HandlerContext, draft: ControllerDraft | MethodDraft): void {
+    const statusArg = ctx.argument(0);
+    const status = readString(statusArg) ?? String(readNumber(statusArg) ?? '200');
+    const description = readString(ctx.argument(1)) ?? 'Ok';
+    const payload = ctx.argument(2);
+    const examples = payload && payload.kind !== 'unresolvable' ?
+        [{ value: payload.raw }] :
+        [];
+    const typeArg = ctx.typeArgument(0);
+    draft.responses.push({
+        name: status,
+        status,
+        description,
+        examples,
+        schema: typeArg ? typeArg.resolve() : undefined,
+    });
+}
+
+function applySecurity(ctx: HandlerContext, draft: ControllerDraft | MethodDraft): void {
+    const scopesArg = ctx.argument(0);
+    const nameArg = ctx.argument(1);
+    const name = readString(nameArg) ?? 'default';
+    const scopes: string[] = [];
+    if (scopesArg?.kind === 'array' && Array.isArray(scopesArg.raw)) {
+        for (const item of scopesArg.raw) {
+            if (typeof item === 'string') scopes.push(item);
+        }
+    } else if (scopesArg?.kind === 'literal' && typeof scopesArg.raw === 'string') {
+        scopes.push(scopesArg.raw);
+    }
+    draft.security ??= [];
+    draft.security.push({ [name]: scopes });
+}
+
+// -----------------------------------------------------------------------------
+// Class-level swagger handlers
+// -----------------------------------------------------------------------------
+
+const classConsumesHandler = controller({
+    match: { name: 'DConsumes', on: 'class' },
+    apply: appendConsumes,
+});
+
+const classDeprecatedHandler = controller({
+    match: { name: 'DDeprecated', on: 'class' },
+    apply: (_ctx, draft) => { (draft as Record<string, unknown>).deprecated = true; },
+    marker: MarkerName.Deprecated,
+});
+
+const classDescriptionHandler = controller({
+    match: { name: 'DDescription', on: 'class' },
+    apply: (ctx, draft) => applyDescription(ctx, draft),
+});
+
+const classHiddenHandler = controller({
+    match: { name: 'DHidden', on: 'class' },
+    apply: (_ctx, draft) => { draft.hidden = true; },
+    marker: MarkerName.Hidden,
+});
+
+const classSecurityHandler = controller({
+    match: { name: 'DSecurity', on: 'class' },
+    apply: (ctx, draft) => applySecurity(ctx, draft),
+});
+
+const classTagsHandler = controller({
+    match: { name: 'DTags', on: 'class' },
+    apply: appendTags,
+});
+
+// -----------------------------------------------------------------------------
+// Method-level swagger handlers
+// -----------------------------------------------------------------------------
+
+const methodConsumesHandler = method({
+    match: { name: 'DConsumes', on: 'method' },
+    apply: appendConsumes,
+});
+
+const methodDeprecatedHandler = method({
+    match: { name: 'DDeprecated', on: 'method' },
+    apply: (_ctx, draft) => { draft.deprecated = true; },
+    marker: MarkerName.Deprecated,
+});
+
+const methodDescriptionHandler = method({
+    match: { name: 'DDescription', on: 'method' },
+    apply: (ctx, draft) => applyDescription(ctx, draft),
+});
+
+const methodExampleHandler = method({
+    match: { name: 'DExample', on: 'method' },
+    apply: (ctx, draft) => {
+        const payload = ctx.argument(0);
+        if (!payload || payload.kind === 'unresolvable') {
+            return;
+        }
+        draft.defaultResponseExamples.push({ value: payload.raw });
+    },
+});
+
+const methodHiddenHandler = method({
+    match: { name: 'DHidden', on: 'method' },
+    apply: (_ctx, draft) => { draft.hidden = true; },
+    marker: MarkerName.Hidden,
+});
+
+const methodSecurityHandler = method({
+    match: { name: 'DSecurity', on: 'method' },
+    apply: (ctx, draft) => applySecurity(ctx, draft),
+});
+
+const methodTagsHandler = method({
+    match: { name: 'DTags', on: 'method' },
+    apply: appendTags,
+});
+
+export function buildSwaggerControllerHandlers(): ControllerHandler[] {
     return [
-        {
-            id: DecoratorID.CONSUMES,
-            name: 'DConsumes',
-            properties: { value: { amount: -1, strategy: 'merge' } },
-        },
-        {
-            id: DecoratorID.DEPRECATED,
-            name: 'DDeprecated',
-        },
-        {
-            id: DecoratorID.DESCRIPTION,
-            name: 'DDescription',
-            properties: {
-                type: { isType: true },
-                payload: { index: 2 },
-                statusCode: { index: 0 },
-                description: { index: 1 },
-            },
-        },
-        {
-            id: DecoratorID.EXAMPLE,
-            name: 'DExample',
-            properties: {
-                type: { isType: true },
-                payload: {},
-            },
-        },
-        {
-            id: DecoratorID.HIDDEN,
-            name: 'DHidden',
-        },
-        {
-            id: DecoratorID.SECURITY,
-            name: 'DSecurity',
-            properties: {
-                key: { index: 1 },
-                value: { index: 0 },
-            },
-        },
-        {
-            id: DecoratorID.TAGS,
-            name: 'DTags',
-            properties: { value: { amount: -1, strategy: 'merge' } },
-        },
+        classConsumesHandler,
+        classDeprecatedHandler,
+        classDescriptionHandler,
+        classHiddenHandler,
+        classSecurityHandler,
+        classTagsHandler,
+    ];
+}
+
+export function buildSwaggerMethodHandlers(): MethodHandler[] {
+    return [
+        methodConsumesHandler,
+        methodDeprecatedHandler,
+        methodDescriptionHandler,
+        methodExampleHandler,
+        methodHiddenHandler,
+        methodSecurityHandler,
+        methodTagsHandler,
     ];
 }

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -57,8 +57,8 @@
     "dependencies": {
         "@routup/assets": "^3.4.2",
         "@routup/swagger-preset": "^2.4.3",
-        "@trapi/metadata": "^2.0.0-beta.0",
-        "@trapi/swagger": "^2.0.0-beta.0",
+        "@trapi/metadata": "^2.0.0-beta.1",
+        "@trapi/swagger": "^2.0.0-beta.1",
         "@types/swagger-ui-dist": "^3.30.5",
         "smob": "^1.4.0",
         "swagger-ui-dist": "^5.32.2"

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -57,7 +57,8 @@
     "dependencies": {
         "@routup/assets": "^3.4.2",
         "@routup/swagger-preset": "^2.4.3",
-        "@trapi/swagger": "^1.3.0",
+        "@trapi/metadata": "^2.0.0-beta.0",
+        "@trapi/swagger": "^2.0.0-beta.0",
         "@types/swagger-ui-dist": "^3.30.5",
         "smob": "^1.4.0",
         "swagger-ui-dist": "^5.32.2"

--- a/packages/swagger/src/generator/module.ts
+++ b/packages/swagger/src/generator/module.ts
@@ -1,49 +1,52 @@
-import { Version, generate as _generate, isMetadata } from '@trapi/swagger';
 import path from 'node:path';
 import process from 'node:process';
+import { isMetadata } from '@trapi/metadata';
+import { Version, generateSwagger } from '@trapi/swagger';
 import { createMerger } from 'smob';
-import type { GeneratorContext, GeneratorOutput } from './type';
+import type { GeneratorContext, GeneratorOptionsInput, GeneratorOutput } from './type';
+
+const DEFAULT_DATA = {
+    name: 'API Documentation',
+    description: 'Explore the REST Endpoints of the API.',
+    consumes: ['application/json'],
+    produces: ['application/json'],
+};
 
 export async function generate<V extends `${Version}`>(
     context: GeneratorContext<V>,
 ): Promise<GeneratorOutput<V>> {
-    if (context.options.metadata) {
-        if (!isMetadata(context.options.metadata)) {
-            if (!context.options.metadata.entryPoint) {
-                context.options.metadata.entryPoint = [
-                    { pattern: '**/*.ts', cwd: path.join(process.cwd(), 'src') },
-                ];
-            }
+    const merge = createMerger({ array: true, arrayDistinct: true });
+    const options = merge({}, DEFAULT_DATA, context.options || {}) as GeneratorOptionsInput;
 
-            if (!context.options.metadata.preset) {
-                context.options.metadata.preset = '@routup/swagger-preset';
-            }
-        }
-    } else {
-        context.options.metadata = {
+    let { metadata } = options;
+    if (!metadata) {
+        metadata = {
             ignore: ['**/node_modules/**'],
             preset: '@routup/swagger-preset',
             entryPoint: [
                 { pattern: '**/*.ts', cwd: path.join(process.cwd(), 'src') },
             ],
         };
+    } else if (!isMetadata(metadata)) {
+        if (!metadata.entryPoint) {
+            metadata.entryPoint = [
+                { pattern: '**/*.ts', cwd: path.join(process.cwd(), 'src') },
+            ];
+        }
+        if (!metadata.preset) {
+            metadata.preset = '@routup/swagger-preset';
+        }
+        if (context.tsconfig && !metadata.tsconfig) {
+            metadata.tsconfig = context.tsconfig;
+        }
     }
 
-    const merge = createMerger({
-        array: true,
-        arrayDistinct: true,
-    });
+    // Strip metadata from `data` so it isn't fed back as a spec extension.
+    const { metadata: _omit, ...data } = options;
 
-    context.options = merge({
-        name: 'API Documentation',
-        description: 'Explore the REST Endpoints of the API.',
-        consumes: ['application/json'],
-        produces: ['application/json'],
-    }, context.options || {});
-
-    return await _generate({
+    return await generateSwagger({
         version: context.version || Version.V3,
-        options: context.options,
-        tsConfig: context.tsconfig,
+        metadata,
+        data,
     }) as GeneratorOutput<V>;
 }

--- a/packages/swagger/src/generator/module.ts
+++ b/packages/swagger/src/generator/module.ts
@@ -27,7 +27,9 @@ export async function generate<V extends `${Version}`>(
                 { pattern: '**/*.ts', cwd: path.join(process.cwd(), 'src') },
             ],
         };
-    } else if (!isMetadata(metadata)) {
+    }
+
+    if (!isMetadata(metadata)) {
         if (!metadata.entryPoint) {
             metadata.entryPoint = [
                 { pattern: '**/*.ts', cwd: path.join(process.cwd(), 'src') },

--- a/packages/swagger/src/generator/type.ts
+++ b/packages/swagger/src/generator/type.ts
@@ -1,30 +1,35 @@
 import type {
     Metadata,
-    MetadataOptions,
-    Options,
-    OptionsInput,
-    SpecV2,
-    SpecV3,
+    MetadataGenerateOptions,
     TsCompilerOptions,
     TsConfig,
-    Version,
+} from '@trapi/metadata';
+import type {
+    SpecV2,
+    SpecV3,
+    SwaggerGenerateData, 
+    Version, 
 } from '@trapi/swagger';
 
-export type GeneratorOutput<V extends `${Version}`> = V extends `${Version.V2}` ? SpecV2 : SpecV3;
+export type GeneratorOutput<V extends `${Version}`> = V extends typeof Version.V2 ? SpecV2 : SpecV3;
+
+export type GeneratorOptionsInput = SwaggerGenerateData & {
+    /**
+     * Pre-built metadata or options to generate metadata from source.
+     */
+    metadata?: MetadataGenerateOptions | Metadata;
+};
+
 export type GeneratorContext<V extends `${Version}`> = {
-    options: OptionsInput,
+    options: GeneratorOptionsInput,
     tsconfig?: TsConfig | string,
     version: V
 };
 
-type GeneratorOptions = Options;
-type GeneratorOptionsInput = OptionsInput;
-type GeneratorMetadataOptions = MetadataOptions;
+type GeneratorMetadataOptions = MetadataGenerateOptions;
 type GeneratorMetadata = Metadata;
 
 export type {
-    GeneratorOptions,
-    GeneratorOptionsInput,
     GeneratorMetadataOptions,
     GeneratorMetadata,
     SpecV2,

--- a/packages/swagger/test/unit/generator/v2/module.spec.ts
+++ b/packages/swagger/test/unit/generator/v2/module.spec.ts
@@ -28,9 +28,6 @@ describe('src/generator/**', () => {
                         pattern: '**/*.ts',
                     },
                 },
-                output: false,
-                outputDirectory: 'writable',
-                yaml: false,
                 servers: ['http://localhost:3000/'],
             },
         });

--- a/packages/swagger/test/unit/generator/v3/module.spec.ts
+++ b/packages/swagger/test/unit/generator/v3/module.spec.ts
@@ -28,9 +28,6 @@ describe('src/generator/**', () => {
                         pattern: '**/*.ts',
                     },
                 },
-                output: false,
-                outputDirectory: 'writable',
-                yaml: false,
                 servers: ['http://localhost:3000/'],
             },
         });
@@ -40,7 +37,7 @@ describe('src/generator/**', () => {
         expect(spec).toBeDefined();
         expect(spec.paths).toBeDefined();
         expect(spec.servers).toBeDefined();
-        expect(spec.openapi).toEqual('3.1.0');
+        expect(spec.openapi).toEqual('3.0.0');
     });
 
     it('should have controller paths', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a TRAPI integration reference and guidance for maintaining external-project cross-references
  * Added commit guidance disallowing AI-attribution trailers

* **Breaking Changes**
  * Generator options no longer accept output, outputDirectory, or yaml
  * Generated OpenAPI v3 output now reports 3.0.0 instead of 3.1.0

* **Chores**
  * Upgraded TRAPI/metadata to v2 beta and aligned preset/metadata handling and generator typing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->