### PR TITLE
feat(decorators)!: built-in body/cookie/query extractors and depend o…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11781,10 +11781,12 @@
             "name": "@routup/decorators",
             "version": "3.4.3",
             "license": "MIT",
-            "devDependencies": {
+            "dependencies": {
                 "@routup/body": "^2.4.3",
                 "@routup/cookie": "^2.4.3",
-                "@routup/query": "^2.4.3",
+                "@routup/query": "^2.4.3"
+            },
+            "devDependencies": {
                 "routup": "^5.0.0-beta.6"
             },
             "peerDependencies": {

--- a/packages/decorators/README.md
+++ b/packages/decorators/README.md
@@ -120,30 +120,22 @@ export class ExampleController {
 | `@DPaths()` | All route parameters |
 | `@DHeader(name)` | Request header by name |
 | `@DHeaders()` | All request headers (`Headers` object) |
-| `@DBody(prop?)` | Request body (requires extractor) |
-| `@DQuery(prop?)` | Query parameter (requires extractor) |
-| `@DCookie(name)` | Cookie by name (requires extractor) |
-| `@DCookies()` | All cookies (requires extractor) |
+| `@DBody(prop?)` | Request body (requires `@routup/body`) |
+| `@DQuery(prop?)` | Query parameter (requires `@routup/query`) |
+| `@DCookie(name)` | Cookie by name (requires `@routup/cookie`) |
+| `@DCookies()` | All cookies (requires `@routup/cookie`) |
 
 ### Installation
 
 The last step is to install the plugin and mount the controllers to a router instance.
 
-Parameters like **body**, **cookie** and **query** cannot be automatically injected into the controller methods. 
-Therefore, so-called parameter getters must be defined, with the help of which the parameters are extracted from the event object.
-If you do not use the corresponding decorator, they do not need to be provided.
+`@DBody`, `@DCookie`/`@DCookies`, and `@DQuery` defer to the helpers from `@routup/body`, `@routup/cookie`, and `@routup/query` — install whichever parsers your controllers actually use. The simplest setup mounts [`@routup/basic`](https://www.npmjs.com/package/@routup/basic), which bundles all three.
 
 `app.ts`
 
 ```typescript
 import { decorators } from '@routup/decorators';
-import {
-    basic,
-    readRequestBody,
-    useRequestCookie,
-    useRequestCookies,
-    useRequestQuery,
-} from '@routup/basic';
+import { basic } from '@routup/basic';
 import { Router, serve } from 'routup';
 
 import { UserController } from './controller';
@@ -153,32 +145,9 @@ const router = new Router();
 router.use(basic());
 router.use(decorators({
     controllers: [
-        UserController
+        UserController,
     ],
-    parameter: {
-        body: async (context, name) => {
-            if (name) {
-                return readRequestBody(context.event, name);
-            }
-
-            return readRequestBody(context.event);
-        },
-        cookie: (context, name) => {
-            if (name) {
-                return useRequestCookie(context.event, name);
-            }
-
-            return useRequestCookies(context.event);
-        },
-        query: (context, name) => {
-            if (name) {
-                return useRequestQuery(context.event, name);
-            }
-
-            return useRequestQuery(context.event);
-        },
-    },
-}))
+}));
 
 serve(router, { port: 3000 });
 ```

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -53,10 +53,12 @@
     "peerDependencies": {
         "routup": "^5.0.0-beta.6"
     },
-    "devDependencies": {
+    "dependencies": {
         "@routup/body": "^2.4.3",
         "@routup/cookie": "^2.4.3",
-        "@routup/query": "^2.4.3",
+        "@routup/query": "^2.4.3"
+    },
+    "devDependencies": {
         "routup": "^5.0.0-beta.6"
     },
     "publishConfig": {

--- a/packages/decorators/src/method/arguments.ts
+++ b/packages/decorators/src/method/arguments.ts
@@ -1,11 +1,13 @@
+import { readRequestBody } from '@routup/body';
+import { useRequestCookie, useRequestCookies } from '@routup/cookie';
+import { useRequestQuery } from '@routup/query';
 import { ParameterType } from '../parameter';
 import type { DecoratorParameterOptions } from '../parameter';
-import type { HandlerContext, ParameterExtractMap } from '../type';
+import type { HandlerContext } from '../type';
 
 export async function buildDecoratorMethodArguments(
     context: HandlerContext,
     parameters: DecoratorParameterOptions[],
-    extractMap?: ParameterExtractMap,
 ): Promise<any[]> {
     /* istanbul ignore next */
     if (
@@ -18,19 +20,6 @@ export async function buildDecoratorMethodArguments(
     const items: unknown[] = [];
 
     for (const parameter of parameters) {
-        if (extractMap) {
-            const extractFn = extractMap[parameter.type];
-            if (extractFn) {
-                if (parameter.property) {
-                    items[parameter.index] = await extractFn(context, parameter.property);
-                } else {
-                    items[parameter.index] = await extractFn(context);
-                }
-
-                continue;
-            }
-        }
-
         if (parameter.type === ParameterType.CONTEXT) {
             items[parameter.index] = context.event;
             continue;
@@ -66,6 +55,27 @@ export async function buildDecoratorMethodArguments(
             } else {
                 items[parameter.index] = context.event.headers;
             }
+            continue;
+        }
+
+        if (parameter.type === ParameterType.BODY) {
+            items[parameter.index] = parameter.property ?
+                await readRequestBody(context.event, parameter.property) :
+                await readRequestBody(context.event);
+            continue;
+        }
+
+        if (parameter.type === ParameterType.QUERY) {
+            items[parameter.index] = parameter.property ?
+                useRequestQuery(context.event, parameter.property) :
+                useRequestQuery(context.event);
+            continue;
+        }
+
+        if (parameter.type === ParameterType.COOKIE) {
+            items[parameter.index] = parameter.property ?
+                useRequestCookie(context.event, parameter.property) :
+                useRequestCookies(context.event);
             continue;
         }
 

--- a/packages/decorators/src/module.ts
+++ b/packages/decorators/src/module.ts
@@ -9,7 +9,6 @@ export function decorators(options: Options) : Plugin {
             mountControllers(
                 router,
                 options.controllers,
-                options.parameter,
             );
         },
     };

--- a/packages/decorators/src/mount.ts
+++ b/packages/decorators/src/mount.ts
@@ -1,13 +1,12 @@
 import type { IRouter, MethodName } from 'routup';
 import { Router, defineCoreHandler } from 'routup';
 import { buildDecoratorMethodArguments } from './method';
-import type { ClassType, ParameterExtractMap } from './type';
+import type { ClassType } from './type';
 import { createHandlerForClassType, isObject, useDecoratorMeta } from './utils';
 
 export function mountController(
     router: IRouter,
     input: (ClassType | Record<string, any>),
-    extractMap?: ParameterExtractMap,
 ) {
     let controller : Record<string, any>;
 
@@ -53,7 +52,6 @@ export function mountController(
                 const args = await buildDecoratorMethodArguments(
                     { event },
                     meta.parameters[propertyKey] ?? [],
-                    extractMap,
                 );
 
                 return controller[propertyKey](...args);
@@ -69,9 +67,8 @@ export function mountController(
 export function mountControllers(
     router: IRouter,
     input: (ClassType | Record<string, any>)[],
-    extractMap?: ParameterExtractMap,
 ) {
     for (const element of input) {
-        mountController(router, element, extractMap);
+        mountController(router, element);
     }
 }

--- a/packages/decorators/src/type.ts
+++ b/packages/decorators/src/type.ts
@@ -1,6 +1,6 @@
 import type { IRoutupEvent } from 'routup';
 import type { DecoratorMethodOptions } from './method';
-import type { DecoratorParameterOptions, ParameterType } from './parameter';
+import type { DecoratorParameterOptions } from './parameter';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export interface ClassType extends Function {
@@ -29,16 +29,6 @@ export type HandlerContext = {
     event: IRoutupEvent,
 };
 
-export type ParameterExtractFn = (
-    context: HandlerContext,
-    key?: string,
-) => any;
-
-export type ParameterExtractMap = {
-    [K in `${ParameterType}`]?: ParameterExtractFn
-};
-
 export type Options = {
     controllers: (ClassType | Record<string, any>)[]
-    parameter?: ParameterExtractMap
 };

--- a/packages/decorators/test/unit/body.spec.ts
+++ b/packages/decorators/test/unit/body.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { body, readRequestBody } from '@routup/body';
-import { Router, defineCoreHandler } from 'routup';
+import { body } from '@routup/body';
+import { Router } from 'routup';
 import { decorators } from '../../src';
 import { PostController } from '../data/post';
 
@@ -14,19 +14,7 @@ describe('data/body', () => {
         const router = new Router();
 
         router.use(body());
-
-        router.use(decorators({
-            controllers: [PostController],
-            parameter: {
-                body: async (context, name) => {
-                    if (name) {
-                        return readRequestBody(context.event, name);
-                    }
-
-                    return readRequestBody(context.event);
-                },
-            },
-        }));
+        router.use(decorators({ controllers: [PostController] }));
 
         let response = await router.fetch(createTestRequest('/post/many', {
             method: 'POST',

--- a/packages/decorators/test/unit/combined.spec.ts
+++ b/packages/decorators/test/unit/combined.spec.ts
@@ -1,7 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { readRequestBody } from '@routup/body';
-import { useRequestCookie, useRequestCookies } from '@routup/cookie';
-import { useRequestQuery } from '@routup/query';
 import { Router } from 'routup';
 import { decorators } from '../../src';
 import { CombinedController } from '../data/combined';
@@ -15,32 +12,7 @@ describe('data/combined', () => {
     it('should handle decorator endpoints', async () => {
         const router = new Router();
 
-        router.use(decorators({
-            controllers: [CombinedController],
-            parameter: {
-                body: async (context, name) => {
-                    if (name) {
-                        return readRequestBody(context.event, name);
-                    }
-
-                    return readRequestBody(context.event);
-                },
-                cookie: (context, name) => {
-                    if (name) {
-                        return useRequestCookie(context.event, name);
-                    }
-
-                    return useRequestCookies(context.event);
-                },
-                query: (context, name) => {
-                    if (name) {
-                        return useRequestQuery(context.event, name);
-                    }
-
-                    return useRequestQuery(context.event);
-                },
-            },
-        }));
+        router.use(decorators({ controllers: [CombinedController] }));
 
         let response = await router.fetch(createTestRequest('/combined'));
 

--- a/packages/decorators/test/unit/cookie.spec.ts
+++ b/packages/decorators/test/unit/cookie.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { cookie, useRequestCookie, useRequestCookies } from '@routup/cookie';
+import { cookie } from '@routup/cookie';
 import { Router } from 'routup';
 import { decorators } from '../../src';
 import { CookieController } from '../data/cookie';
@@ -14,18 +14,7 @@ describe('data/cookie', () => {
         const router = new Router();
 
         router.use(cookie());
-        router.use(decorators({
-            controllers: [CookieController],
-            parameter: {
-                cookie: (context, name) => {
-                    if (name) {
-                        return useRequestCookie(context.event, name);
-                    }
-
-                    return useRequestCookies(context.event);
-                },
-            },
-        }));
+        router.use(decorators({ controllers: [CookieController] }));
 
         let response = await router.fetch(createTestRequest('/cookie/many', { headers: { cookie: 'foo=bar' } }));
 

--- a/packages/decorators/test/unit/query.spec.ts
+++ b/packages/decorators/test/unit/query.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { query, useRequestQuery } from '@routup/query';
+import { query } from '@routup/query';
 import { Router } from 'routup';
 import { decorators } from '../../src';
 import { QueryController } from '../data/query';
@@ -14,18 +14,7 @@ describe('src/decorator', () => {
         const router = new Router();
 
         router.use(query());
-        router.use(decorators({
-            controllers: [QueryController],
-            parameter: {
-                query: (context, name) => {
-                    if (name) {
-                        return useRequestQuery(context.event, name);
-                    }
-
-                    return useRequestQuery(context.event);
-                },
-            },
-        }));
+        router.use(decorators({ controllers: [QueryController] }));
 
         let response = await router.fetch(createTestRequest('/query/many?foo=bar'));
 

--- a/packages/docs/src/decorators/index.md
+++ b/packages/docs/src/decorators/index.md
@@ -51,7 +51,7 @@ export class UserController {
 // app.ts
 import { Router, serve } from 'routup';
 import { decorators } from '@routup/decorators';
-import { basic, readRequestBody, useRequestCookie, useRequestQuery } from '@routup/basic';
+import { basic } from '@routup/basic';
 import { UserController } from './controller';
 
 const router = new Router();
@@ -59,11 +59,6 @@ const router = new Router();
 router.use(basic());
 router.use(decorators({
     controllers: [UserController],
-    parameter: {
-        body: (ctx, name) => name ? readRequestBody(ctx.event, name) : readRequestBody(ctx.event),
-        cookie: (ctx, name) => useRequestCookie(ctx.event, name as string),
-        query: (ctx, name) => name ? useRequestQuery(ctx.event, name) : useRequestQuery(ctx.event),
-    },
 }));
 
 serve(router, { port: 3000 });
@@ -80,6 +75,6 @@ The plugin doesn't replace `defineCoreHandler` — it sits alongside it. You can
 ## See also
 
 - [Controllers](./controllers) — `@DController`, HTTP method decorators, async handlers, returning a `Response`
-- [Parameters](./parameters) — every parameter decorator with its parser-extractor wiring
+- [Parameters](./parameters) — every parameter decorator and the parser plugins it relies on
 - [`@routup/swagger`](/swagger/) — generate OpenAPI from your decorated controllers
 - [`@routup/swagger-preset`](/swagger-preset/) — the metadata preset that maps `@DController` / `@DGet` / `@DBody` to OpenAPI

--- a/packages/docs/src/decorators/parameters.md
+++ b/packages/docs/src/decorators/parameters.md
@@ -1,71 +1,59 @@
 ---
 title: Decorators — Parameters
-description: Parameter decorators and the parser-extractor wiring they depend on.
+description: Parameter decorators with built-in body, cookie, and query extraction.
 relatedPlugins: [body, cookie, query, basic]
 ---
 
 # Parameter decorators
 
-Parameter decorators inject typed values into a controller method. Some are extracted directly from the event; others (body, cookie, query) require you to **register an extractor function** when installing the plugin, because routup itself doesn't ship a body parser.
+Parameter decorators inject typed values into a controller method. The helpers backing `@DBody`, `@DCookie`/`@DCookies`, and `@DQuery` defer to [`@routup/body`](/body/), [`@routup/cookie`](/cookie/), and [`@routup/query`](/query/) respectively — install whichever parsers your controllers actually use. No extractor wiring required.
 
 ## Reference table
 
-| Decorator | Source | Extractor required? |
-|---|---|---|
-| `@DContext()` | `IRoutupEvent` | No |
-| `@DRequest()` | `event.request` | No |
-| `@DResponse()` | `event.response` | No |
-| `@DNext()` | `event.next` | No |
-| `@DPath(name)` | `event.params[name]` | No |
-| `@DPaths()` | `event.params` | No |
-| `@DHeader(name)` | `event.headers.get(name)` | No |
-| `@DHeaders()` | `event.headers` | No |
-| `@DBody(prop?)` | extractor from `parameter.body` | **Yes** |
-| `@DQuery(prop?)` | extractor from `parameter.query` | **Yes** |
-| `@DCookie(name)` | extractor from `parameter.cookie` | **Yes** |
-| `@DCookies()` | extractor from `parameter.cookie` (no name) | **Yes** |
+| Decorator | Source |
+|---|---|
+| `@DContext()` | `IRoutupEvent` |
+| `@DRequest()` | `event.request` |
+| `@DResponse()` | `event.response` |
+| `@DNext()` | `event.next` |
+| `@DPath(name)` | `event.params[name]` |
+| `@DPaths()` | `event.params` |
+| `@DHeader(name)` | `event.headers.get(name)` |
+| `@DHeaders()` | `event.headers` |
+| `@DBody(prop?)` | `readRequestBody(event[, prop])` |
+| `@DQuery(prop?)` | `useRequestQuery(event[, prop])` |
+| `@DCookie(name)` | `useRequestCookie(event, name)` |
+| `@DCookies()` | `useRequestCookies(event)` |
 
-## Wiring extractors
+## Setup
 
-Body, cookie, and query are not built into routup core — they live in dedicated plugins. The decorators plugin asks you to map each to the helper of your choice. Pair with [`@routup/basic`](/basic/) (or its individual sub-plugins) for the standard wiring:
+Install whichever parsers your controllers actually use, then mount decorators. The simplest setup uses [`@routup/basic`](/basic/), which bundles all three:
 
 ```typescript
 import { Router } from 'routup';
+import { basic } from '@routup/basic';
 import { decorators } from '@routup/decorators';
-import {
-    basic,
-    readRequestBody,
-    useRequestCookie,
-    useRequestCookies,
-    useRequestQuery,
-} from '@routup/basic';
 
 const router = new Router();
 
 router.use(basic());
 router.use(decorators({
     controllers: [UserController],
-    parameter: {
-        body: async (ctx, name) => {
-            return name
-                ? readRequestBody(ctx.event, name)
-                : readRequestBody(ctx.event);
-        },
-        cookie: (ctx, name) => {
-            return name
-                ? useRequestCookie(ctx.event, name)
-                : useRequestCookies(ctx.event);
-        },
-        query: (ctx, name) => {
-            return name
-                ? useRequestQuery(ctx.event, name)
-                : useRequestQuery(ctx.event);
-        },
-    },
 }));
 ```
 
-The `ctx` argument the extractor receives carries the event plus decorator metadata. Custom extractors are how you'd plug in `multer`-style file-upload helpers, schema validation (via [validup](https://github.com/tada5hi/validup)), or a different cookie store.
+If you'd rather pick parsers individually — for instance to skip cookies or pass non-default body options — install them directly:
+
+```typescript
+import { body } from '@routup/body';
+import { cookie } from '@routup/cookie';
+import { query } from '@routup/query';
+
+router.use(body({ json: { limit: '5mb' } }));
+router.use(cookie());
+router.use(query());
+router.use(decorators({ controllers: [UserController] }));
+```
 
 ## Examples
 
@@ -105,4 +93,5 @@ export class UserController {
 ## See also
 
 - [Controllers](./controllers) — `@DController` and HTTP method decorators
-- [`@routup/basic`](/basic/) — the standard parser bundle most extractors are built on
+- [`@routup/basic`](/basic/) — bundle of body, cookie, and query parsers
+- [`@routup/body`](/body/) · [`@routup/cookie`](/cookie/) · [`@routup/query`](/query/) — the parsers decorators depends on

--- a/packages/docs/src/decorators/parameters.md
+++ b/packages/docs/src/decorators/parameters.md
@@ -94,4 +94,4 @@ export class UserController {
 
 - [Controllers](./controllers) — `@DController` and HTTP method decorators
 - [`@routup/basic`](/basic/) — bundle of body, cookie, and query parsers
-- [`@routup/body`](/body/) · [`@routup/cookie`](/cookie/) · [`@routup/query`](/query/) — the parsers decorators depends on
+- [`@routup/body`](/body/) · [`@routup/cookie`](/cookie/) · [`@routup/query`](/query/) — the parsers that `@routup/decorators` depends on


### PR DESCRIPTION
…n individual parsers

Decorators no longer require consumers to wire up extractor functions for @DBody, @DCookie, @DCookies, and @DQuery. The plugin now ships built-in extractors that defer to the standard helpers from @routup/body, @routup/cookie, and @routup/query — install whichever parser plugins your controllers actually use.

BREAKING CHANGES:
- The `parameter` option (and the `ParameterExtractFn` / `ParameterExtractMap` types) has been removed from the decorators plugin. Custom extractors are no longer supported; install the matching parser plugin instead.
- @routup/body, @routup/cookie, and @routup/query are now runtime dependencies of @routup/decorators (previously devDependencies).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parameter decorators (@DBody, @DQuery, @DCookie) now include built-in extraction behavior; no custom wiring required.

* **Documentation**
  * Updated parameter decorator documentation to reflect simplified setup and built-in extraction functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->