### PR TITLE
feat(decorators)!: bump routup to ^5.0.0 and migrate preset to @trapi…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "node": ">=22.0.0"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         },
         "node_modules/@algolia/abtesting": {
@@ -1099,7 +1099,6 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
@@ -1113,7 +1112,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -1123,7 +1121,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -2894,34 +2891,45 @@
             "dev": true,
             "license": "Apache-2.0"
         },
-        "node_modules/@trapi/metadata": {
-            "version": "2.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/@trapi/metadata/-/metadata-2.0.0-beta.2.tgz",
-            "integrity": "sha512-7RK84oN6h1RlWOpDmmFsQxMSIoy/RzRA2WPBiALJ9DVg8/qRSWM6vG/qiuPYn1PmSopMY+xBnDjADPxHGjozIw==",
-            "dev": true,
+        "node_modules/@trapi/core": {
+            "version": "2.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@trapi/core/-/core-2.0.0-beta.3.tgz",
+            "integrity": "sha512-S0iLcpdy1EBdrvW1puEAJP709hmg97vQ9potaWeEa4pbwNKXaCsuMFEKiyBEpd/LEsk8IK01oHhpvd3Zrcepvw==",
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.0.1",
                 "@validup/adapter-zod": "^0.2.4",
-                "flatted": "^3.3.3",
                 "locter": "^2.1.6",
-                "minimatch": "^10.0.3",
                 "validup": "^0.2.2",
                 "zod": "^4.4.2"
+            }
+        },
+        "node_modules/@trapi/metadata": {
+            "version": "2.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@trapi/metadata/-/metadata-2.0.0-beta.3.tgz",
+            "integrity": "sha512-fq694iGKM02QMiDNBbciH5j5vcAo44R4S6n7RjXLU6K1ice6+DnNj6sf+AXVW9dEZ5cjV9EAYp02bXuca5BBuw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ebec/core": "^1.0.1",
+                "@trapi/core": "2.0.0-beta.3",
+                "flatted": "^3.3.3",
+                "locter": "^2.1.6",
+                "minimatch": "^10.0.3"
             },
             "peerDependencies": {
                 "typescript": ">=5.0.0"
             }
         },
         "node_modules/@trapi/swagger": {
-            "version": "2.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/@trapi/swagger/-/swagger-2.0.0-beta.2.tgz",
-            "integrity": "sha512-lphaUNRzRMN3h798KOhVBXACnGp7fVl/W95FrYm+ajSBwrc0UYq0jVDyBIpJNJHA8CZoG+yeB461Kx5Gd0Wd4Q==",
+            "version": "2.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@trapi/swagger/-/swagger-2.0.0-beta.3.tgz",
+            "integrity": "sha512-wCkBfHbMw78sIMrfOidIaiKzmxub47zVfd6sW1CGODhxqAKcx4FDhr3Ic5piKuC2pXJyTlN6w8OWqjtcn53kEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.0.1",
-                "@trapi/metadata": "^2.0.0-beta.2",
+                "@trapi/core": "2.0.0-beta.3",
                 "smob": "^1.5.0",
                 "yamljs": "^0.3.0"
             },
@@ -3374,7 +3382,6 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/@validup/adapter-zod/-/adapter-zod-0.2.4.tgz",
             "integrity": "sha512-iNzKKFStFDwx4GYo7hvhlo4elVaj2OA1BiEtWGC7LWIUD4aoLq2EhjY2sfRlHM2ILinlJIAlWZXIB9j0s1bS9w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "validup": "^0.2.2"
@@ -4185,7 +4192,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
@@ -4986,7 +4992,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
             "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/detect-libc": {
@@ -5104,7 +5109,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/ebec/-/ebec-2.3.0.tgz",
             "integrity": "sha512-bt+0tSL7223VU3PSVi0vtNLZ8pO1AfWolcPPMk2a/a5H+o/ZU9ky0n3A0zhrR4qzJTN61uPsGIO4ShhOukdzxA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/ejs": {
@@ -5626,7 +5630,6 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -5643,7 +5646,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -5695,7 +5697,6 @@
             "version": "1.20.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -5762,7 +5763,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -5805,7 +5805,6 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "bin": {
                 "flat": "cli.js"
@@ -6577,7 +6576,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -6597,7 +6595,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -6620,7 +6617,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -6699,7 +6695,6 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -7311,7 +7306,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/locter/-/locter-2.2.1.tgz",
             "integrity": "sha512-Cc7mowptFl7ug5he6Iuos7aGRd9xbwTfnx1ng4AX/7F4iqemPaXAIJDi13IBwQZrKgli9OPEYXm6uCKr7ynxUQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "destr": "^2.0.5",
@@ -7700,7 +7694,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -7809,7 +7802,6 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
@@ -7823,7 +7815,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -9147,7 +9138,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -9340,7 +9330,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
@@ -9508,9 +9497,9 @@
             }
         },
         "node_modules/routup": {
-            "version": "5.0.0-beta.6",
-            "resolved": "https://registry.npmjs.org/routup/-/routup-5.0.0-beta.6.tgz",
-            "integrity": "sha512-wEA8T4K2TP66aG2EZvU7QwLXAdE3GRXLQsojaGMAY9ow3GLwCSxubi+7cezw/zJhz8fAFeQF3pguYU+YhfwkOg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/routup/-/routup-5.0.0.tgz",
+            "integrity": "sha512-K2eza+ynGYrjGJlm7CY014ePVcXPJYLniETNWdK+uYHh7I9pWQBhdj6sxNLluGi9O9Ra914gqraJ7xl+grPP6A==",
             "license": "MIT",
             "workspaces": [
                 "docs"
@@ -9533,7 +9522,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -10223,7 +10211,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -10651,7 +10638,6 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/validup/-/validup-0.2.2.tgz",
             "integrity": "sha512-Abq/gSS1ze2BQWkYkKU7cOqS0cwi0brtDOowKltZf5iylnQxGbBZK7JRuEfKB/XFgfimfna6Z5I1x++XQVCgjQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "pathtrace": "^2.1.2",
@@ -10665,7 +10651,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/pathtrace/-/pathtrace-2.2.0.tgz",
             "integrity": "sha512-HbWXrGk6NYlvwvDSX6JVpbGXTAgqAXhpYmgK5P0PPrGQ0//smfXQ8/SIP+fC3HueG+007KDDRNQHTgr1q7D0gg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=22.0.0"
@@ -11619,7 +11604,6 @@
             "version": "2.8.3",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
             "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
@@ -11755,7 +11739,6 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
@@ -11776,10 +11759,10 @@
             "version": "3.4.2",
             "license": "MIT",
             "devDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         },
         "packages/basic": {
@@ -11792,10 +11775,10 @@
                 "@routup/query": "^2.4.3"
             },
             "devDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         },
         "packages/body": {
@@ -11803,10 +11786,10 @@
             "version": "2.4.3",
             "license": "MIT",
             "devDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         },
         "packages/cookie": {
@@ -11817,10 +11800,10 @@
                 "cookie-es": "^3.1.1"
             },
             "devDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         },
         "packages/decorators": {
@@ -11830,22 +11813,17 @@
             "dependencies": {
                 "@routup/body": "^2.4.3",
                 "@routup/cookie": "^2.4.3",
-                "@routup/query": "^2.4.3"
+                "@routup/query": "^2.4.3",
+                "@trapi/core": "^2.0.0-beta.3"
             },
             "devDependencies": {
-                "@trapi/metadata": "^2.0.0-beta.2",
-                "@trapi/swagger": "^2.0.0-beta.2",
+                "@trapi/metadata": "^2.0.0-beta.3",
+                "@trapi/swagger": "^2.0.0-beta.3",
                 "jsonata": "^2.1.0",
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
-                "@trapi/metadata": ">=2.0.0-beta.2 <3.0.0",
-                "routup": "^5.0.0-beta.6"
-            },
-            "peerDependenciesMeta": {
-                "@trapi/metadata": {
-                    "optional": true
-                }
+                "routup": "^5.0.0"
             }
         },
         "packages/docs": {
@@ -11863,11 +11841,11 @@
             "license": "MIT",
             "devDependencies": {
                 "ilingo": "^5.0.0",
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
                 "ilingo": "^5.0.0",
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         },
         "packages/prometheus": {
@@ -11876,11 +11854,11 @@
             "license": "MIT",
             "devDependencies": {
                 "prom-client": "^15.1.3",
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
                 "prom-client": ">=15.0.0",
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         },
         "packages/query": {
@@ -11892,10 +11870,10 @@
                 "qs": "^6.15.1"
             },
             "devDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         },
         "packages/rate-limit": {
@@ -11903,10 +11881,10 @@
             "version": "2.4.2",
             "license": "MIT",
             "devDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         },
         "packages/rate-limit-redis": {
@@ -11916,12 +11894,12 @@
             "devDependencies": {
                 "@routup/rate-limit": "^2.4.2",
                 "redis-extension": "^2.0.4",
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
                 "@routup/rate-limit": "^2.4.2",
                 "redis-extension": "^2.0.4",
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependenciesMeta": {
                 "redis-extension": {
@@ -11988,11 +11966,11 @@
             },
             "devDependencies": {
                 "@types/swagger-ui-dist": "^3.30.5",
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             },
             "peerDependencies": {
                 "@types/swagger-ui-dist": "^3.30.5",
-                "routup": "^5.0.0-beta.6"
+                "routup": "^5.0.0"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1099,6 +1099,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
@@ -1112,6 +1113,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -1121,6 +1123,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -2895,6 +2898,7 @@
             "version": "2.0.0-beta.3",
             "resolved": "https://registry.npmjs.org/@trapi/core/-/core-2.0.0-beta.3.tgz",
             "integrity": "sha512-S0iLcpdy1EBdrvW1puEAJP709hmg97vQ9potaWeEa4pbwNKXaCsuMFEKiyBEpd/LEsk8IK01oHhpvd3Zrcepvw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.0.1",
@@ -3382,6 +3386,7 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/@validup/adapter-zod/-/adapter-zod-0.2.4.tgz",
             "integrity": "sha512-iNzKKFStFDwx4GYo7hvhlo4elVaj2OA1BiEtWGC7LWIUD4aoLq2EhjY2sfRlHM2ILinlJIAlWZXIB9j0s1bS9w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "validup": "^0.2.2"
@@ -4192,6 +4197,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
@@ -4992,6 +4998,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
             "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/detect-libc": {
@@ -5109,6 +5116,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/ebec/-/ebec-2.3.0.tgz",
             "integrity": "sha512-bt+0tSL7223VU3PSVi0vtNLZ8pO1AfWolcPPMk2a/a5H+o/ZU9ky0n3A0zhrR4qzJTN61uPsGIO4ShhOukdzxA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/ejs": {
@@ -5630,6 +5638,7 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -5646,6 +5655,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -5697,6 +5707,7 @@
             "version": "1.20.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -5763,6 +5774,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -5805,6 +5817,7 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "bin": {
                 "flat": "cli.js"
@@ -6576,6 +6589,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -6595,6 +6609,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -6617,6 +6632,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -6695,6 +6711,7 @@
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -7306,6 +7323,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/locter/-/locter-2.2.1.tgz",
             "integrity": "sha512-Cc7mowptFl7ug5he6Iuos7aGRd9xbwTfnx1ng4AX/7F4iqemPaXAIJDi13IBwQZrKgli9OPEYXm6uCKr7ynxUQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "destr": "^2.0.5",
@@ -7694,6 +7712,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -7802,6 +7821,7 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
@@ -7815,6 +7835,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -9138,6 +9159,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -9330,6 +9352,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
@@ -9522,6 +9545,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -10211,6 +10235,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -10638,6 +10663,7 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/validup/-/validup-0.2.2.tgz",
             "integrity": "sha512-Abq/gSS1ze2BQWkYkKU7cOqS0cwi0brtDOowKltZf5iylnQxGbBZK7JRuEfKB/XFgfimfna6Z5I1x++XQVCgjQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "pathtrace": "^2.1.2",
@@ -10651,6 +10677,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/pathtrace/-/pathtrace-2.2.0.tgz",
             "integrity": "sha512-HbWXrGk6NYlvwvDSX6JVpbGXTAgqAXhpYmgK5P0PPrGQ0//smfXQ8/SIP+fC3HueG+007KDDRNQHTgr1q7D0gg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=22.0.0"
@@ -11604,6 +11631,7 @@
             "version": "2.8.3",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
             "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
@@ -11739,6 +11767,7 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
@@ -11813,17 +11842,23 @@
             "dependencies": {
                 "@routup/body": "^2.4.3",
                 "@routup/cookie": "^2.4.3",
-                "@routup/query": "^2.4.3",
-                "@trapi/core": "^2.0.0-beta.3"
+                "@routup/query": "^2.4.3"
             },
             "devDependencies": {
+                "@trapi/core": "^2.0.0-beta.3",
                 "@trapi/metadata": "^2.0.0-beta.3",
                 "@trapi/swagger": "^2.0.0-beta.3",
                 "jsonata": "^2.1.0",
                 "routup": "^5.0.0"
             },
             "peerDependencies": {
+                "@trapi/core": ">=2.0.0-beta.3 <3.0.0",
                 "routup": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@trapi/core": {
+                    "optional": true
+                }
             }
         },
         "packages/docs": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
         "prepare": "husky"
     },
     "peerDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     }
 }

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -52,10 +52,10 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "devDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -63,7 +63,7 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "dependencies": {
         "@routup/body": "^2.4.3",
@@ -71,7 +71,7 @@
         "@routup/query": "^2.4.3"
     },
     "devDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "gitHead": "94d729e309c1eec0401afb4d8083f65ce3aa8e0b",
     "publishConfig": {

--- a/packages/body/package.json
+++ b/packages/body/package.json
@@ -49,10 +49,10 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "devDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/cookie/package.json
+++ b/packages/cookie/package.json
@@ -51,13 +51,13 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "dependencies": {
         "cookie-es": "^3.1.1"
     },
     "devDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "gitHead": "94d729e309c1eec0401afb4d8083f65ce3aa8e0b",
     "publishConfig": {

--- a/packages/decorators/README.md
+++ b/packages/decorators/README.md
@@ -155,26 +155,30 @@ serve(router, { port: 3000 });
 
 ## OpenAPI generation
 
-`@routup/decorators` ships a [`@trapi/metadata`](https://github.com/trapi/trapi) preset under the `./preset` subpath that decodes routup's `@D*` decorators into the schema TRAPI's generators understand. There's no separate generator package — call `@trapi/swagger` directly, or wire the preset into the `trapi` CLI.
+`@routup/decorators` ships a [TRAPI](https://github.com/trapi/trapi) preset under the `./preset` subpath that decodes routup's `@D*` decorators into the schema TRAPI's generators understand. There's no separate generator package — extract metadata with `@trapi/metadata`, hand it to `@trapi/swagger`, or wire the preset into the `trapi` CLI.
 
 ### Programmatically
 
+`@trapi/swagger`'s `generateSwagger()` accepts pre-built metadata, so call `generateMetadata()` from `@trapi/metadata` first. Reference the preset by package specifier — `@trapi/metadata` resolves it via the `preset` export of `@routup/decorators/preset`:
+
 ```typescript
+import { generateMetadata } from '@trapi/metadata';
 import { generateSwagger, Version, saveSwagger } from '@trapi/swagger';
-import { buildPreset } from '@routup/decorators/preset';
 import process from 'node:process';
 import path from 'node:path';
 
+const metadata = await generateMetadata({
+    preset: '@routup/decorators/preset',
+    entryPoint: {
+        cwd: path.join(process.cwd(), 'src'),
+        pattern: '**/*.ts',
+    },
+    ignore: ['**/node_modules/**'],
+});
+
 const spec = await generateSwagger({
     version: Version.V3_2,
-    metadata: {
-        preset: buildPreset(),
-        entryPoint: {
-            cwd: path.join(process.cwd(), 'src'),
-            pattern: '**/*.ts',
-        },
-        ignore: ['**/node_modules/**'],
-    },
+    metadata,
     data: {
         name: 'My API',
         servers: ['http://localhost:3000/'],
@@ -183,6 +187,8 @@ const spec = await generateSwagger({
 
 await saveSwagger(spec, { outputDirectory: 'writable' });
 ```
+
+If you need to customise the preset before passing it in, import `buildPreset` from `@routup/decorators/preset` and supply the returned object as `preset` instead of the string identifier.
 
 Pair the result with [`@routup/swagger-ui`](https://www.npmjs.com/package/@routup/swagger-ui) to serve the generated document at runtime.
 
@@ -194,7 +200,7 @@ Skip the JS glue entirely — the CLI accepts the preset by name:
 npx trapi --preset @routup/decorators/preset
 ```
 
-`@trapi/metadata` is declared as an optional peer dependency, so consumers who never generate OpenAPI don't pay for it. Install it (and `@trapi/swagger`) only when you actually call into the generator.
+The preset itself depends on `@trapi/core` (bundled as a runtime dependency). Install `@trapi/metadata` and `@trapi/swagger` only when you actually call into the generator.
 
 ## License
 

--- a/packages/decorators/README.md
+++ b/packages/decorators/README.md
@@ -200,7 +200,7 @@ Skip the JS glue entirely — the CLI accepts the preset by name:
 npx trapi --preset @routup/decorators/preset
 ```
 
-The preset itself depends on `@trapi/core` (bundled as a runtime dependency). Install `@trapi/metadata` and `@trapi/swagger` only when you actually call into the generator.
+`@trapi/core` is declared as an *optional* peer dependency, so runtime-only consumers of `@routup/decorators` never pay for it. Install it (alongside `@trapi/metadata` and `@trapi/swagger`) only when you actually call into the generator.
 
 ## License
 

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -55,24 +55,19 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
-        "@trapi/metadata": ">=2.0.0-beta.2 <3.0.0",
-        "routup": "^5.0.0-beta.6"
-    },
-    "peerDependenciesMeta": {
-        "@trapi/metadata": {
-            "optional": true
-        }
+        "routup": "^5.0.0"
     },
     "dependencies": {
         "@routup/body": "^2.4.3",
         "@routup/cookie": "^2.4.3",
-        "@routup/query": "^2.4.3"
+        "@routup/query": "^2.4.3",
+        "@trapi/core": "^2.0.0-beta.3"
     },
     "devDependencies": {
-        "@trapi/metadata": "^2.0.0-beta.2",
-        "@trapi/swagger": "^2.0.0-beta.2",
+        "@trapi/metadata": "^2.0.0-beta.3",
+        "@trapi/swagger": "^2.0.0-beta.3",
         "jsonata": "^2.1.0",
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/decorators/package.json
+++ b/packages/decorators/package.json
@@ -55,15 +55,21 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
+        "@trapi/core": ">=2.0.0-beta.3 <3.0.0",
         "routup": "^5.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@trapi/core": {
+            "optional": true
+        }
     },
     "dependencies": {
         "@routup/body": "^2.4.3",
         "@routup/cookie": "^2.4.3",
-        "@routup/query": "^2.4.3",
-        "@trapi/core": "^2.0.0-beta.3"
+        "@routup/query": "^2.4.3"
     },
     "devDependencies": {
+        "@trapi/core": "^2.0.0-beta.3",
         "@trapi/metadata": "^2.0.0-beta.3",
         "@trapi/swagger": "^2.0.0-beta.3",
         "jsonata": "^2.1.0",

--- a/packages/decorators/src/preset/class.ts
+++ b/packages/decorators/src/preset/class.ts
@@ -2,7 +2,7 @@ import {
     type ControllerHandler,
     controller,
     setControllerPaths,
-} from '@trapi/metadata';
+} from '@trapi/core';
 
 const dControllerHandler = controller({
     match: { name: 'DController', on: 'class' },

--- a/packages/decorators/src/preset/index.ts
+++ b/packages/decorators/src/preset/index.ts
@@ -2,4 +2,6 @@ import { buildPreset } from './module';
 
 export * from './module';
 
-export const preset = buildPreset();
+const preset = buildPreset();
+
+export default preset;

--- a/packages/decorators/src/preset/method.ts
+++ b/packages/decorators/src/preset/method.ts
@@ -3,7 +3,7 @@ import {
     type MethodHandler,
     method,
     setMethodPath,
-} from '@trapi/metadata';
+} from '@trapi/core';
 
 function setVerbAndPath(verb: MethodDraft['verb']): MethodHandler['apply'] {
     return (ctx, draft) => {

--- a/packages/decorators/src/preset/module.ts
+++ b/packages/decorators/src/preset/module.ts
@@ -1,4 +1,4 @@
-import type { Preset } from '@trapi/metadata';
+import type { Preset } from '@trapi/core';
 import { buildClassHandlers } from './class';
 import { buildMethodHandlers } from './method';
 import { buildParameterHandlers } from './parameter';

--- a/packages/decorators/src/preset/parameter.ts
+++ b/packages/decorators/src/preset/parameter.ts
@@ -3,7 +3,7 @@ import {
     type ParameterHandler,
     parameter,
     readString,
-} from '@trapi/metadata';
+} from '@trapi/core';
 
 const dContextHandler = parameter({
     match: { name: 'DContext', on: 'parameter' },

--- a/packages/decorators/src/preset/swagger.ts
+++ b/packages/decorators/src/preset/swagger.ts
@@ -10,7 +10,7 @@ import {
     method,
     readNumber,
     readString,
-} from '@trapi/metadata';
+} from '@trapi/core';
 
 const appendTags = append('tags').positionalAll();
 const appendConsumes = append('consumes').positionalAll();

--- a/packages/decorators/test/unit/preset/v2.spec.ts
+++ b/packages/decorators/test/unit/preset/v2.spec.ts
@@ -4,6 +4,7 @@ import {
     expect,
     it,
 } from 'vitest';
+import { generateMetadata } from '@trapi/metadata';
 import { Version, generateSwagger } from '@trapi/swagger';
 import type { SpecV2 } from '@trapi/swagger';
 import jsonata from 'jsonata';
@@ -17,16 +18,18 @@ describe('src/preset (V2)', () => {
     let spec : SpecV2;
 
     beforeAll(async () => {
+        const metadata = await generateMetadata({
+            cache: false,
+            preset: buildPreset(),
+            entryPoint: {
+                cwd: controllerDirectoryPath,
+                pattern: '**/*.ts',
+            },
+        });
+
         spec = await generateSwagger({
             version: Version.V2,
-            metadata: {
-                cache: false,
-                preset: buildPreset(),
-                entryPoint: {
-                    cwd: controllerDirectoryPath,
-                    pattern: '**/*.ts',
-                },
-            },
+            metadata,
             data: { servers: ['http://localhost:3000/'] },
         });
     });

--- a/packages/decorators/test/unit/preset/v3.spec.ts
+++ b/packages/decorators/test/unit/preset/v3.spec.ts
@@ -4,6 +4,7 @@ import {
     expect,
     it,
 } from 'vitest';
+import { generateMetadata } from '@trapi/metadata';
 import { Version, generateSwagger } from '@trapi/swagger';
 import type { SpecV3 } from '@trapi/swagger';
 import jsonata from 'jsonata';
@@ -17,16 +18,18 @@ describe('src/preset (V3)', () => {
     let spec : SpecV3;
 
     beforeAll(async () => {
+        const metadata = await generateMetadata({
+            cache: false,
+            preset: buildPreset(),
+            entryPoint: {
+                cwd: controllerDirectoryPath,
+                pattern: '**/*.ts',
+            },
+        });
+
         spec = await generateSwagger({
             version: Version.V3,
-            metadata: {
-                cache: false,
-                preset: buildPreset(),
-                entryPoint: {
-                    cwd: controllerDirectoryPath,
-                    pattern: '**/*.ts',
-                },
-            },
+            metadata,
             data: { servers: ['http://localhost:3000/'] },
         });
     });

--- a/packages/docs/src/decorators/index.md
+++ b/packages/docs/src/decorators/index.md
@@ -8,7 +8,7 @@ relatedPlugins: [basic, body, cookie, query, swagger-ui]
 
 Define request handlers as classes with TypeScript decorators, then mount them on any routup router. Familiar shape if you're coming from NestJS, tsoa, or Spring — controllers, parameter injection, declarative paths.
 
-The same decorator metadata also drives OpenAPI generation: this package ships a [`@trapi/metadata`](https://github.com/trapi/trapi) preset under the `./preset` subpath, so the same controller serves as both your routing surface and your API contract. See [OpenAPI generation](#openapi-generation) below.
+The same decorator metadata also drives OpenAPI generation: this package ships a [TRAPI](https://github.com/trapi/trapi) preset under the `./preset` subpath, so the same controller serves as both your routing surface and your API contract. See [OpenAPI generation](#openapi-generation) below.
 
 ## Installation
 
@@ -74,26 +74,30 @@ The plugin doesn't replace `defineCoreHandler` — it sits alongside it. You can
 
 ## OpenAPI generation
 
-`@routup/decorators` exposes a [`@trapi/metadata`](https://github.com/trapi/trapi) preset under the `./preset` subpath that maps `@DController` / `@DGet` / `@DBody` / `@DQuery` / etc. into the schema TRAPI's generators consume. There is no dedicated `@routup/swagger-generator` package — call `@trapi/swagger` directly, or use the `trapi` CLI.
+`@routup/decorators` exposes a [TRAPI](https://github.com/trapi/trapi) preset under the `./preset` subpath that maps `@DController` / `@DGet` / `@DBody` / `@DQuery` / etc. into the schema TRAPI's generators consume. There is no dedicated `@routup/swagger-generator` package — extract metadata with `@trapi/metadata`, feed it into `@trapi/swagger`, or use the `trapi` CLI.
 
 ### Programmatically
 
+`generateSwagger()` accepts pre-built metadata, so run `generateMetadata()` from `@trapi/metadata` first. The preset can be referenced by package specifier — `@trapi/metadata` resolves it through the `preset` export of `@routup/decorators/preset`:
+
 ```typescript
+import { generateMetadata } from '@trapi/metadata';
 import { generateSwagger, Version, saveSwagger } from '@trapi/swagger';
-import { buildPreset } from '@routup/decorators/preset';
 import process from 'node:process';
 import path from 'node:path';
 
+const metadata = await generateMetadata({
+    preset: '@routup/decorators/preset',
+    entryPoint: {
+        cwd: path.join(process.cwd(), 'src'),
+        pattern: '**/*.ts',
+    },
+    ignore: ['**/node_modules/**'],
+});
+
 const spec = await generateSwagger({
     version: Version.V3_2,
-    metadata: {
-        preset: buildPreset(),
-        entryPoint: {
-            cwd: path.join(process.cwd(), 'src'),
-            pattern: '**/*.ts',
-        },
-        ignore: ['**/node_modules/**'],
-    },
+    metadata,
     data: {
         name: 'My API',
         servers: ['http://localhost:3000/'],
@@ -103,6 +107,8 @@ const spec = await generateSwagger({
 await saveSwagger(spec, { outputDirectory: 'writable' });
 ```
 
+To customise the preset before generation, import `buildPreset` from `@routup/decorators/preset` and pass the returned object as `preset` instead of the string identifier.
+
 Hand the result to [`@routup/swagger-ui`](/swagger-ui/) to serve the document at runtime.
 
 ### Via the trapi CLI
@@ -111,7 +117,7 @@ Hand the result to [`@routup/swagger-ui`](/swagger-ui/) to serve the document at
 npx trapi --preset @routup/decorators/preset
 ```
 
-`@trapi/metadata` is declared as an *optional* peer dependency on `@routup/decorators`, so runtime-only consumers never pay for it. Install it (and `@trapi/swagger`) only when you call into the generator.
+The preset depends on `@trapi/core` (bundled as a runtime dependency of `@routup/decorators`). `@trapi/metadata` and `@trapi/swagger` are only needed when you call into the generator yourself — install them on demand.
 
 ## See also
 

--- a/packages/docs/src/decorators/index.md
+++ b/packages/docs/src/decorators/index.md
@@ -117,7 +117,7 @@ Hand the result to [`@routup/swagger-ui`](/swagger-ui/) to serve the document at
 npx trapi --preset @routup/decorators/preset
 ```
 
-The preset depends on `@trapi/core` (bundled as a runtime dependency of `@routup/decorators`). `@trapi/metadata` and `@trapi/swagger` are only needed when you call into the generator yourself — install them on demand.
+`@trapi/core` is declared as an *optional* peer dependency on `@routup/decorators`, so runtime-only consumers never pay for it. Install it (alongside `@trapi/metadata` and `@trapi/swagger`) only when you call into the generator.
 
 ## See also
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -48,11 +48,11 @@
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
         "ilingo": "^5.0.0",
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "devDependencies": {
         "ilingo": "^5.0.0",
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "gitHead": "94d729e309c1eec0401afb4d8083f65ce3aa8e0b",
     "publishConfig": {

--- a/packages/prometheus/package.json
+++ b/packages/prometheus/package.json
@@ -45,11 +45,11 @@
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
         "prom-client": ">=15.0.0",
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "devDependencies": {
         "prom-client": "^15.1.3",
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -52,14 +52,14 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "dependencies": {
         "@types/qs": "^6.14.0",
         "qs": "^6.15.1"
     },
     "devDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "gitHead": "94d729e309c1eec0401afb4d8083f65ce3aa8e0b",
     "publishConfig": {

--- a/packages/rate-limit-redis/package.json
+++ b/packages/rate-limit-redis/package.json
@@ -49,7 +49,7 @@
     "peerDependencies": {
         "@routup/rate-limit": "^2.4.2",
         "redis-extension": "^2.0.4",
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "peerDependenciesMeta": {
         "redis-extension": {
@@ -59,7 +59,7 @@
     "devDependencies": {
         "@routup/rate-limit": "^2.4.2",
         "redis-extension": "^2.0.4",
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/rate-limit/package.json
+++ b/packages/rate-limit/package.json
@@ -46,10 +46,10 @@
     },
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "devDependencies": {
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/swagger-ui/package.json
+++ b/packages/swagger-ui/package.json
@@ -53,7 +53,7 @@
     "homepage": "https://github.com/routup/plugins#readme",
     "peerDependencies": {
         "@types/swagger-ui-dist": "^3.30.5",
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "dependencies": {
         "@routup/assets": "^3.4.2",
@@ -61,7 +61,7 @@
     },
     "devDependencies": {
         "@types/swagger-ui-dist": "^3.30.5",
-        "routup": "^5.0.0-beta.6"
+        "routup": "^5.0.0"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
…/core

- bump peer routup to ^5.0.0 across all packages
- replace @trapi/metadata peer dep with @trapi/core runtime dep on @routup/decorators
- preset sources now import from @trapi/core
- generateSwagger only accepts pre-built metadata: tests + docs call generateMetadata first
- export preset as default from @routup/decorators/preset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all packages to stable Routup 5.0.0 from beta.6
  * Added @trapi/core as a runtime dependency for the decorators package

* **Documentation**
  * Clarified decorators preset usage and OpenAPI generation workflow
  * Updated documentation with customization and dependency guidance

* **Tests**
  * Updated preset tests to reflect new metadata generation approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->