### PR TITLE
feat(cors): add @routup/cors plugin

### DIFF
--- a/.agents/references/h3.md
+++ b/.agents/references/h3.md
@@ -1,0 +1,79 @@
+---
+name: h3 reference
+description: Mapping between h3's web-API utilities and the routup plugins they are ported into (currently @routup/cors).
+type: reference
+---
+
+# h3 Reference
+
+[h3](https://github.com/h3js/h3) is an unjs HTTP framework whose utilities run on Web Standard `Request` / `Response`. Several routup plugins port specific h3 utilities — keep this file updated whenever h3 changes the corresponding source.
+
+Repo: <https://github.com/h3js/h3> — pull individual files via `https://raw.githubusercontent.com/h3js/h3/main/src/...`.
+
+## Version snapshot (as of 2026-05-06)
+
+| | Version | Source |
+|---|---|---|
+| `h3` | `2.0.1-rc.22` (commit `84244b4`) | `src/utils/cors.ts`, `src/utils/internal/cors.ts` |
+
+Bump the snapshot whenever you sync — the SHA + path makes drift easy to spot.
+
+## Code mapping (h3 → routup/plugins)
+
+### CORS — `@routup/cors`
+
+| h3 (`src/utils/...`) | routup (`packages/cors/src/...`) | Notes |
+|---|---|---|
+| `cors.ts` `CorsOptions` | `types.ts` `Options` | Same fields. Routup adds `ResolvedOptions` + `CorsHeaderEntry` for the post-resolve shape. |
+| `cors.ts` `isPreflightRequest(event)` | `utils.ts` `isPreflightRequest(event)` | Identical semantics. h3 reads `event.req.headers`; we use `getRequestHeader(event, ...)` and `event.method`. |
+| `cors.ts` `appendCorsPreflightHeaders` | `handler.ts` `appendCorsPreflightHeaders` | We always run `resolveOptions(options)` so callers can pass raw `Options`. h3 expects already-resolved options when called via `handleCors` and accepts raw via the public re-export. |
+| `cors.ts` `appendCorsHeaders` | `handler.ts` `appendCorsHeaders` | Same as above. |
+| `cors.ts` `handleCors` | `handler.ts` `handleCors` | Returns `Response \| undefined` instead of h3's `false \| HTTPResponse`. Routup callers do `const r = handleCors(event, opts); if (r) return r;`. |
+| `internal/cors.ts` `resolveCorsOptions` | `utils.ts` `resolveOptions` | Renamed (the package scope is `cors`, the prefix would be redundant). The credentials-with-wildcard `console.warn` has moved out of resolve and runs **once at plugin install** (`createHandler`), not per-call. |
+| `internal/cors.ts` `isCorsOriginAllowed` | `utils.ts` `isCorsOriginAllowed` | Identical. |
+| `internal/cors.ts` `createOriginHeaders` | `utils.ts` `createOriginHeaders` | Returns `CorsHeaderEntry[]` (tuples) instead of `Record<string, string>` so multiple `vary` entries survive. See [Vary header fix](#vary-header-fix). |
+| `internal/cors.ts` `createMethodsHeaders` | `utils.ts` `createMethodsHeaders` | Tuple-array port. |
+| `internal/cors.ts` `createCredentialsHeaders` | `utils.ts` `createCredentialsHeaders` | Tuple-array port. |
+| `internal/cors.ts` `createAllowHeaderHeaders` | `utils.ts` `createAllowHeaderHeaders` | Tuple-array port. |
+| `internal/cors.ts` `createExposeHeaders` | `utils.ts` `createExposeHeaders` | Tuple-array port. Adds `exposeHeaders.length === 0` guard (h3 returns `''` joined; we drop the header). |
+| `internal/cors.ts` `createMaxAgeHeader` | `utils.ts` `createMaxAgeHeader` | Tuple-array port. |
+| _(no equivalent)_ | `utils.ts` `applyHeaders` | Routup-side merger that uses `appendResponseHeader` for `vary` and `event.response.headers.set` for everything else. |
+| _(no equivalent)_ | `module.ts` `cors()` + `handler.ts` `createHandler` | Routup `Plugin` shape: `cors(options)` returns `{ name, install }`; the handler calls `event.next()` for non-preflight, otherwise returns a `new Response(null, { status, headers: event.response.headers })`. |
+
+## Behavioral differences
+
+### Vary header fix
+
+h3's `appendCors*` builds the response header set by spreading record objects:
+
+```ts
+const headers = {
+    ...createOriginHeaders(...),  // may emit { vary: 'origin' }
+    ...createAllowHeaderHeaders(...), // may emit { vary: 'access-control-request-headers' }
+};
+```
+
+When **both** `origin` and `allowHeaders` are concrete (e.g. allowlisted origin + listed headers on a preflight), the second spread overwrites the first `vary` value — only `access-control-request-headers` ends up on the response. The routup port returns header tuples (`Array<[name, value]>`) and uses `appendResponseHeader` for `vary` so both values are preserved (deduped by the underlying `Headers` impl when needed). There is a regression test for this at `packages/cors/test/unit/module.spec.ts` (`should preserve both vary values when origin and allowHeaders are concrete`).
+
+### Credentials warning
+
+h3 calls `console.warn` from inside `resolveCorsOptions` — meaning every `handleCors`, `appendCorsHeaders`, and `appendCorsPreflightHeaders` call re-warns. The routup port emits the warning **once**, inside `createHandler`, when the plugin is installed. The standalone helpers (`appendCorsHeaders` etc.) are silent.
+
+### `handleCors` return shape
+
+h3: `false | HTTPResponse` (truthy = handled).
+routup: `Response | undefined` (truthy = handled). Same `if (cors !== false)` / `if (cors)` ergonomics; just nicer to type-check.
+
+## When to re-sync
+
+Re-pull `src/utils/cors.ts` + `src/utils/internal/cors.ts` whenever:
+1. h3 cuts a new RC / stable on the `2.x` track (watch the GitHub release feed).
+2. Anyone files an MDN-spec interpretation issue against `@routup/cors` — h3 may already have fixed it.
+3. The browser CORS spec changes (rare, but e.g. `Access-Control-Allow-Private-Network` is in flight).
+
+After syncing, update the version snapshot above with the commit SHA, and run:
+
+```bash
+npx nx run @routup/cors:test
+npx nx run @routup/cors:build
+```

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -9,6 +9,7 @@ plugins/
 │   ├── basic/          # Bundle: body + cookie + query
 │   ├── body/           # Request body parsing
 │   ├── cookie/         # Cookie read/write
+│   ├── cors/           # Native CORS — preflight + Access-Control-* headers
 │   ├── decorators/     # Class/method/parameter decorators (also exports ./preset for trapi)
 │   ├── i18n/           # Request translation
 │   ├── prometheus/     # Metrics collection (prom-client)
@@ -53,6 +54,7 @@ packages/[name]/
 | `basic` | `@routup/basic` | Body + cookie + query bundle | `@routup/body`, `@routup/cookie`, `@routup/query` |
 | `body` | `@routup/body` | Parse JSON, form, text, raw bodies | — |
 | `cookie` | `@routup/cookie` | Read/serialize cookies | `cookie` |
+| `cors` | `@routup/cors` | Native CORS handling (preflight + headers), ported from h3 | — |
 | `decorators` | `@routup/decorators` | Route decorators + `./preset` subpath (the `@trapi/metadata` preset for `@D*`) | `@routup/body`, `@routup/cookie`, `@routup/query`; optional peer `@trapi/metadata` |
 | `i18n` | `@routup/i18n` | Request translations | — |
 | `prometheus` | `@routup/prometheus` | Metrics + /metrics endpoint | `prom-client` |
@@ -68,7 +70,7 @@ OpenAPI generation is not a routup-owned package — call `@trapi/swagger`'s `ge
 ```
 Layer 3 (composites):   basic
 Layer 2 (adapters):     rate-limit-redis, swagger-ui
-Layer 1 (standalone):   assets, body, cookie, decorators, i18n, prometheus, query, rate-limit
+Layer 1 (standalone):   assets, body, cookie, cors, decorators, i18n, prometheus, query, rate-limit
 ```
 
 All packages peer-depend on `routup@^4.0.1`.

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -73,4 +73,4 @@ Layer 2 (adapters):     rate-limit-redis, swagger-ui
 Layer 1 (standalone):   assets, body, cookie, cors, decorators, i18n, prometheus, query, rate-limit
 ```
 
-All packages peer-depend on `routup@^4.0.1`.
+All packages peer-depend on `routup@^5.0.0`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ typically http framework functions, which are not integrated in the main package
 | [basic](packages/basic)                       | Bundle of the [body](packages/body), [cookie](packages/cookie) and [query](packages/query) plugin. |
 | [body](packages/body)                         | Read and parse the request body.                                                                   |
 | [cookie](packages/cookie)                     | Read and parse request cookies and serialize cookies for the response.                             |
+| [cors](packages/cors)                         | Native CORS handling — preflight + `Access-Control-*` response headers.                            |
 | [decorators](packages/decorators)             | Create request handlers with class-, method- & parameter-decorators.                               |
 | [i18n](packages/i18n)                         | Provide translations for incoming requests.                                                        |
 | [prometheus](packages/prometheus)             | Collect and serve metrics for prometheus.                                                          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2327,6 +2327,10 @@
             "resolved": "packages/cookie",
             "link": true
         },
+        "node_modules/@routup/cors": {
+            "resolved": "packages/cors",
+            "link": true
+        },
         "node_modules/@routup/decorators": {
             "resolved": "packages/decorators",
             "link": true
@@ -11846,6 +11850,17 @@
             "dependencies": {
                 "cookie-es": "^3.1.1"
             },
+            "devDependencies": {
+                "routup": "^5.0.0"
+            },
+            "peerDependencies": {
+                "routup": "^5.0.0"
+            }
+        },
+        "packages/cors": {
+            "name": "@routup/cors",
+            "version": "0.0.0",
+            "license": "MIT",
             "devDependencies": {
                 "routup": "^5.0.0"
             },

--- a/packages/cors/CHANGELOG.md
+++ b/packages/cors/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/cors/LICENSE
+++ b/packages/cors/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Peter Placzek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cors/README.md
+++ b/packages/cors/README.md
@@ -57,13 +57,14 @@ serve(router, { port: 3000 });
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `origin` | `'*' \| 'null' \| (string \| RegExp)[] \| (origin) => boolean` | `'*'` | Value of `Access-Control-Allow-Origin`. Arrays / RegExp / functions match against the request `Origin`. |
+| `origin` | `boolean \| string \| RegExp \| (string \| RegExp)[] \| (origin) => boolean` | `'*'` | Value of `Access-Control-Allow-Origin`. `true` reflects the request origin (credentials-friendly); `false` skips CORS entirely. A bare string is emitted verbatim (`'*'`, `'null'`, or any concrete origin). A RegExp / array / function reflects the request origin on match. |
 | `methods` | `'*' \| string[]` | `'*'` | Value of `Access-Control-Allow-Methods` on preflight. |
 | `allowHeaders` | `'*' \| string[]` | `'*'` | Value of `Access-Control-Allow-Headers` on preflight. When `'*'` or empty, mirrors the request's `Access-Control-Request-Headers`. |
 | `exposeHeaders` | `'*' \| string[]` | `'*'` | Value of `Access-Control-Expose-Headers`. |
 | `credentials` | `boolean` | `false` | Sets `Access-Control-Allow-Credentials: true`. With credentials, none of `origin` / `methods` / `allowHeaders` / `exposeHeaders` may be `'*'` — browsers will reject the response. |
-| `maxAge` | `string \| false` | `false` | Value of `Access-Control-Max-Age` on preflight. |
-| `preflight.statusCode` | `number` | `204` | Status code returned for preflight responses. |
+| `maxAge` | `string \| number \| false` | `false` | Value of `Access-Control-Max-Age` on preflight, in seconds. Numbers are stringified. |
+| `preflightContinue` | `boolean` | `false` | When `true`, sets the preflight headers and calls `event.next()` instead of returning a 204 — lets your own `OPTIONS` handler take over. |
+| `preflight.status` | `number` | `204` | Status code returned for preflight responses. Preflight responses also set `Content-Length: 0` for Safari compatibility. |
 
 ## Helpers
 

--- a/packages/cors/README.md
+++ b/packages/cors/README.md
@@ -102,7 +102,7 @@ declare function appendCorsHeaders(
 
 ### `appendCorsPreflightHeaders`
 
-Appends the preflight set (`Allow-Methods`, `Allow-Headers`, `Max-Age`, etc.) to `event.response.headers`. Caller is responsible for returning a `Response`.
+Appends the preflight set (`Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Max-Age`, etc.) to `event.response.headers`. Caller is responsible for returning a `Response`.
 
 ```typescript
 declare function appendCorsPreflightHeaders(

--- a/packages/cors/README.md
+++ b/packages/cors/README.md
@@ -6,7 +6,7 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/Tada5hi/routup/badge.svg)](https://snyk.io/test/github/Tada5hi/routup)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 
-A native CORS plugin for routup — handles preflight (`OPTIONS`) requests and adds `Access-Control-*` response headers without going through `fromNodeMiddleware`.
+A CORS plugin for routup — handles preflight (`OPTIONS`) requests and adds `Access-Control-*` response headers.
 
 **Table of Contents**
 

--- a/packages/cors/README.md
+++ b/packages/cors/README.md
@@ -1,0 +1,137 @@
+# @routup/cors
+
+[![npm version](https://badge.fury.io/js/@routup%2Fcors.svg)](https://badge.fury.io/js/@routup%2Fcors)
+[![main](https://github.com/Tada5hi/routup/actions/workflows/main.yml/badge.svg)](https://github.com/Tada5hi/routup/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/tada5hi/routup/branch/master/graph/badge.svg?token=CLIA667K6V)](https://codecov.io/gh/tada5hi/routup)
+[![Known Vulnerabilities](https://snyk.io/test/github/Tada5hi/routup/badge.svg)](https://snyk.io/test/github/Tada5hi/routup)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+
+A native CORS plugin for routup — handles preflight (`OPTIONS`) requests and adds `Access-Control-*` response headers without going through `fromNodeMiddleware`.
+
+**Table of Contents**
+
+- [Installation](#installation)
+- [Documentation](#documentation)
+- [Usage](#usage)
+- [Options](#options)
+- [Helpers](#helpers)
+  - [handleCors](#handlecors)
+  - [appendCorsHeaders](#appendcorsheaders)
+  - [appendCorsPreflightHeaders](#appendcorspreflightheaders)
+  - [isPreflightRequest](#ispreflightrequest)
+  - [isCorsOriginAllowed](#iscorsoriginallowed)
+- [License](#license)
+
+## Installation
+
+```bash
+npm install @routup/cors --save
+```
+
+## Documentation
+
+To read the docs, visit [https://routup.net](https://routup.net)
+
+## Usage
+
+Mount the plugin once at the top of the router. It both adds CORS headers to ordinary responses and short-circuits preflight `OPTIONS` requests with a 204.
+
+```typescript
+import { Router, defineCoreHandler, serve } from 'routup';
+import { cors } from '@routup/cors';
+
+const router = new Router();
+
+router.use(cors({
+    origin: ['https://app.example.com'],
+    credentials: true,
+    allowHeaders: ['content-type', 'authorization'],
+}));
+
+router.get('/', defineCoreHandler(() => 'ok'));
+
+serve(router, { port: 3000 });
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `origin` | `'*' \| 'null' \| (string \| RegExp)[] \| (origin) => boolean` | `'*'` | Value of `Access-Control-Allow-Origin`. Arrays / RegExp / functions match against the request `Origin`. |
+| `methods` | `'*' \| string[]` | `'*'` | Value of `Access-Control-Allow-Methods` on preflight. |
+| `allowHeaders` | `'*' \| string[]` | `'*'` | Value of `Access-Control-Allow-Headers` on preflight. When `'*'` or empty, mirrors the request's `Access-Control-Request-Headers`. |
+| `exposeHeaders` | `'*' \| string[]` | `'*'` | Value of `Access-Control-Expose-Headers`. |
+| `credentials` | `boolean` | `false` | Sets `Access-Control-Allow-Credentials: true`. With credentials, none of `origin` / `methods` / `allowHeaders` / `exposeHeaders` may be `'*'` — browsers will reject the response. |
+| `maxAge` | `string \| false` | `false` | Value of `Access-Control-Max-Age` on preflight. |
+| `preflight.statusCode` | `number` | `204` | Status code returned for preflight responses. |
+
+## Helpers
+
+### `handleCors`
+
+All-in-one helper: appends headers and, on a preflight request, returns the preflight `Response`. Useful inside an existing handler when you don't want to install the plugin globally.
+
+```typescript
+declare function handleCors(
+    event: IRoutupEvent,
+    options: Options,
+): Response | undefined;
+```
+
+```typescript
+router.all('/', defineCoreHandler((event) => {
+    const corsResponse = handleCors(event, { origin: '*' });
+    if (corsResponse) {
+        return corsResponse;
+    }
+    // your handler logic
+    return 'ok';
+}));
+```
+
+### `appendCorsHeaders`
+
+Appends the standard `Access-Control-Allow-*` and `Access-Control-Expose-Headers` to the current response. No-op on preflight detection — pair with `appendCorsPreflightHeaders` if you handle preflight yourself.
+
+```typescript
+declare function appendCorsHeaders(
+    event: IRoutupEvent,
+    options: Options,
+): void;
+```
+
+### `appendCorsPreflightHeaders`
+
+Appends the preflight set (`Allow-Methods`, `Allow-Headers`, `Max-Age`, etc.) to `event.response.headers`. Caller is responsible for returning a `Response`.
+
+```typescript
+declare function appendCorsPreflightHeaders(
+    event: IRoutupEvent,
+    options: Options,
+): void;
+```
+
+### `isPreflightRequest`
+
+Returns `true` when the request is `OPTIONS` with both an `Origin` header and an `Access-Control-Request-Method` header.
+
+```typescript
+declare function isPreflightRequest(event: IRoutupEvent): boolean;
+```
+
+### `isCorsOriginAllowed`
+
+Pure helper that evaluates the `origin` option against an origin string. Useful for custom decisions outside the plugin.
+
+```typescript
+declare function isCorsOriginAllowed(
+    origin: string | null | undefined,
+    options: Options,
+): boolean;
+```
+
+## License
+
+Made with 💚
+
+Published under [MIT License](./LICENSE).

--- a/packages/cors/package.json
+++ b/packages/cors/package.json
@@ -1,0 +1,64 @@
+{
+    "name": "@routup/cors",
+    "version": "0.0.0",
+    "type": "module",
+    "description": "CORS plugin for routup.",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "types": "./dist/index.d.mts",
+            "import": "./dist/index.mjs"
+        }
+    },
+    "types": "./dist/index.d.mts",
+    "files": [
+        "dist/"
+    ],
+    "scripts": {
+        "build": "npm run build:js && npm run build:types",
+        "build:js": "rimraf ./dist && tsdown",
+        "build:types": "tsc --noEmit -p tsconfig.build.json",
+        "test": "vitest run --config ./test/vitest.config.ts",
+        "test:coverage": "vitest run --config ./test/vitest.config.ts --coverage",
+        "lint": "eslint ./src",
+        "lint:fix": "npm run lint -- --fix"
+    },
+    "author": {
+        "name": "Peter Placzek",
+        "email": "contact@tada5hi.net",
+        "url": "https://github.com/tada5hi"
+    },
+    "license": "MIT",
+    "keywords": [
+        "cors",
+        "cross-origin",
+        "preflight",
+        "access-control",
+        "middleware",
+        "api",
+        "rest",
+        "http",
+        "router",
+        "api-router",
+        "route",
+        "routing"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/routup/plugins.git",
+        "directory": "packages/cors"
+    },
+    "bugs": {
+        "url": "https://github.com/routup/plugins/issues"
+    },
+    "homepage": "https://github.com/routup/plugins#readme",
+    "peerDependencies": {
+        "routup": "^5.0.0"
+    },
+    "devDependencies": {
+        "routup": "^5.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/cors/src/handler.ts
+++ b/packages/cors/src/handler.ts
@@ -1,0 +1,72 @@
+import type { IRoutupEvent } from 'routup';
+import { defineCoreHandler } from 'routup';
+import type { Options } from './types';
+import {
+    applyHeaders,
+    createAllowHeaderHeaders,
+    createCredentialsHeaders,
+    createExposeHeaders,
+    createMaxAgeHeader,
+    createMethodsHeaders,
+    createOriginHeaders,
+    isPreflightRequest,
+    resolveOptions,
+} from './utils';
+
+export function appendCorsPreflightHeaders(event: IRoutupEvent, options: Options): void {
+    const resolved = resolveOptions(options);
+    applyHeaders(event, [
+        ...createOriginHeaders(event, resolved),
+        ...createCredentialsHeaders(resolved),
+        ...createMethodsHeaders(resolved),
+        ...createAllowHeaderHeaders(event, resolved),
+        ...createMaxAgeHeader(resolved),
+    ]);
+}
+
+export function appendCorsHeaders(event: IRoutupEvent, options: Options): void {
+    const resolved = resolveOptions(options);
+    applyHeaders(event, [
+        ...createOriginHeaders(event, resolved),
+        ...createCredentialsHeaders(resolved),
+        ...createExposeHeaders(resolved),
+    ]);
+}
+
+export function handleCors(event: IRoutupEvent, options: Options): Response | undefined {
+    if (isPreflightRequest(event)) {
+        appendCorsPreflightHeaders(event, options);
+        const statusCode = options.preflight?.statusCode ?? 204;
+        return new Response(null, {
+            status: statusCode,
+            headers: event.response.headers,
+        });
+    }
+
+    appendCorsHeaders(event, options);
+    return undefined;
+}
+
+export function createHandler(input?: Options) {
+    const options = resolveOptions(input);
+
+    if (options.credentials && (!input?.origin || input.origin === '*')) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            '[@routup/cors] `credentials: true` with wildcard origin is not allowed. Browsers will reject the response.',
+        );
+    }
+
+    return defineCoreHandler((event) => {
+        if (isPreflightRequest(event)) {
+            appendCorsPreflightHeaders(event, options);
+            return new Response(null, {
+                status: options.preflight.statusCode,
+                headers: event.response.headers,
+            });
+        }
+
+        appendCorsHeaders(event, options);
+        return event.next();
+    });
+}

--- a/packages/cors/src/handler.ts
+++ b/packages/cors/src/handler.ts
@@ -1,6 +1,6 @@
 import type { IRoutupEvent } from 'routup';
 import { defineCoreHandler } from 'routup';
-import type { Options } from './types';
+import type { Options, ResolvedOptions } from './types';
 import {
     applyHeaders,
     createAllowHeaderHeaders,
@@ -13,8 +13,7 @@ import {
     resolveOptions,
 } from './utils';
 
-export function appendCorsPreflightHeaders(event: IRoutupEvent, options: Options): void {
-    const resolved = resolveOptions(options);
+function applyResolvedCorsPreflightHeaders(event: IRoutupEvent, resolved: ResolvedOptions): void {
     applyHeaders(event, [
         ...createOriginHeaders(event, resolved),
         ...createCredentialsHeaders(resolved),
@@ -24,8 +23,7 @@ export function appendCorsPreflightHeaders(event: IRoutupEvent, options: Options
     ]);
 }
 
-export function appendCorsHeaders(event: IRoutupEvent, options: Options): void {
-    const resolved = resolveOptions(options);
+function applyResolvedCorsHeaders(event: IRoutupEvent, resolved: ResolvedOptions): void {
     applyHeaders(event, [
         ...createOriginHeaders(event, resolved),
         ...createCredentialsHeaders(resolved),
@@ -33,40 +31,70 @@ export function appendCorsHeaders(event: IRoutupEvent, options: Options): void {
     ]);
 }
 
+export function appendCorsPreflightHeaders(event: IRoutupEvent, options: Options): void {
+    applyResolvedCorsPreflightHeaders(event, resolveOptions(options));
+}
+
+export function appendCorsHeaders(event: IRoutupEvent, options: Options): void {
+    applyResolvedCorsHeaders(event, resolveOptions(options));
+}
+
 export function handleCors(event: IRoutupEvent, options: Options): Response | undefined {
+    const resolved = resolveOptions(options);
     if (isPreflightRequest(event)) {
-        appendCorsPreflightHeaders(event, options);
-        const statusCode = options.preflight?.statusCode ?? 204;
+        applyResolvedCorsPreflightHeaders(event, resolved);
         return new Response(null, {
-            status: statusCode,
+            status: resolved.preflight.statusCode,
             headers: event.response.headers,
         });
     }
 
-    appendCorsHeaders(event, options);
+    applyResolvedCorsHeaders(event, resolved);
     return undefined;
+}
+
+function warnInvalidCredentialsCombination(input: Options, resolved: ResolvedOptions): void {
+    if (!resolved.credentials) {
+        return;
+    }
+
+    const wildcardFields: string[] = [];
+    if (!input.origin || input.origin === '*') {
+        wildcardFields.push('origin');
+    }
+    if (resolved.methods === '*') {
+        wildcardFields.push('methods');
+    }
+    if (resolved.allowHeaders === '*') {
+        wildcardFields.push('allowHeaders');
+    }
+    if (resolved.exposeHeaders === '*') {
+        wildcardFields.push('exposeHeaders');
+    }
+
+    if (wildcardFields.length > 0) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            `[@routup/cors] credentials: true cannot be combined with '*' for ${wildcardFields.join(', ')}. Browsers will reject the response.`,
+        );
+    }
 }
 
 export function createHandler(input?: Options) {
     const options = resolveOptions(input);
 
-    if (options.credentials && (!input?.origin || input.origin === '*')) {
-        // eslint-disable-next-line no-console
-        console.warn(
-            '[@routup/cors] `credentials: true` with wildcard origin is not allowed. Browsers will reject the response.',
-        );
-    }
+    warnInvalidCredentialsCombination(input ?? {}, options);
 
     return defineCoreHandler((event) => {
         if (isPreflightRequest(event)) {
-            appendCorsPreflightHeaders(event, options);
+            applyResolvedCorsPreflightHeaders(event, options);
             return new Response(null, {
                 status: options.preflight.statusCode,
                 headers: event.response.headers,
             });
         }
 
-        appendCorsHeaders(event, options);
+        applyResolvedCorsHeaders(event, options);
         return event.next();
     });
 }

--- a/packages/cors/src/handler.ts
+++ b/packages/cors/src/handler.ts
@@ -31,6 +31,15 @@ function applyResolvedCorsHeaders(event: IRoutupEvent, resolved: ResolvedOptions
     ]);
 }
 
+function buildPreflightResponse(event: IRoutupEvent, resolved: ResolvedOptions): Response {
+    const headers = new Headers(event.response.headers);
+    headers.set('content-length', '0');
+    return new Response(null, {
+        status: resolved.preflight.status,
+        headers,
+    });
+}
+
 export function appendCorsPreflightHeaders(event: IRoutupEvent, options: Options): void {
     applyResolvedCorsPreflightHeaders(event, resolveOptions(options));
 }
@@ -41,12 +50,16 @@ export function appendCorsHeaders(event: IRoutupEvent, options: Options): void {
 
 export function handleCors(event: IRoutupEvent, options: Options): Response | undefined {
     const resolved = resolveOptions(options);
+    if (resolved.origin === false) {
+        return undefined;
+    }
+
     if (isPreflightRequest(event)) {
         applyResolvedCorsPreflightHeaders(event, resolved);
-        return new Response(null, {
-            status: resolved.preflight.statusCode,
-            headers: event.response.headers,
-        });
+        if (resolved.preflightContinue) {
+            return undefined;
+        }
+        return buildPreflightResponse(event, resolved);
     }
 
     applyResolvedCorsHeaders(event, resolved);
@@ -59,7 +72,7 @@ function warnInvalidCredentialsCombination(input: Options, resolved: ResolvedOpt
     }
 
     const wildcardFields: string[] = [];
-    if (!input.origin || input.origin === '*') {
+    if (input.origin === undefined || input.origin === '*') {
         wildcardFields.push('origin');
     }
     if (resolved.methods === '*') {
@@ -86,12 +99,16 @@ export function createHandler(input?: Options) {
     warnInvalidCredentialsCombination(input ?? {}, options);
 
     return defineCoreHandler((event) => {
+        if (options.origin === false) {
+            return event.next();
+        }
+
         if (isPreflightRequest(event)) {
             applyResolvedCorsPreflightHeaders(event, options);
-            return new Response(null, {
-                status: options.preflight.statusCode,
-                headers: event.response.headers,
-            });
+            if (options.preflightContinue) {
+                return event.next();
+            }
+            return buildPreflightResponse(event, options);
         }
 
         applyResolvedCorsHeaders(event, options);

--- a/packages/cors/src/index.ts
+++ b/packages/cors/src/index.ts
@@ -1,0 +1,14 @@
+import {
+    cors,
+} from './module';
+
+export * from './handler';
+export * from './module';
+export * from './types';
+export {
+    isCorsOriginAllowed,
+    isPreflightRequest,
+    resolveOptions,
+} from './utils';
+
+export default cors;

--- a/packages/cors/src/module.ts
+++ b/packages/cors/src/module.ts
@@ -1,0 +1,12 @@
+import type { Plugin } from 'routup';
+import { createHandler } from './handler';
+import type { Options } from './types';
+
+export function cors(options: Options = {}): Plugin {
+    return {
+        name: 'cors',
+        install: (router) => {
+            router.use(createHandler(options));
+        },
+    };
+}

--- a/packages/cors/src/types.ts
+++ b/packages/cors/src/types.ts
@@ -1,16 +1,23 @@
-export type CorsOriginOption = '*' |
-    'null' |
+export type CorsOriginOption = boolean |
+    string |
+    RegExp |
     (string | RegExp)[] |
     ((origin: string) => boolean);
 
 export type CorsListOption = '*' | string[];
 
+export type CorsMaxAgeOption = string | number | false;
+
 export type Options = {
     /**
      * Determines the value of the `access-control-allow-origin` response header.
+     * - `true` reflects the request `Origin` (credentials-friendly equivalent of `'*'`).
+     * - `false` skips CORS handling entirely (no headers, preflight passes through).
      * - `'*'` allows all origins.
      * - `'null'` allows opaque (sandboxed) origins.
-     * - An array of strings / RegExps is matched against the request `Origin`.
+     * - A bare string is emitted as-is (e.g. `'https://app.example.com'`).
+     * - A `RegExp` is matched against the request `Origin`; on match, the origin is reflected.
+     * - An array of strings / RegExps is iterated; on first match, the origin is reflected.
      * - A function receives the request `Origin` and returns `true` if allowed.
      *
      * @default '*'
@@ -49,11 +56,21 @@ export type Options = {
     credentials?: boolean;
 
     /**
-     * Value of `access-control-max-age` for preflight responses.
+     * Value of `access-control-max-age` for preflight responses, in seconds.
+     * Numbers are stringified.
      *
      * @default false
      */
-    maxAge?: string | false;
+    maxAge?: CorsMaxAgeOption;
+
+    /**
+     * When `true`, preflight responses set the `Access-Control-*` headers and
+     * then call `event.next()` so the user's own `OPTIONS` handler can take
+     * over. When `false` (default), the plugin short-circuits with a 204.
+     *
+     * @default false
+     */
+    preflightContinue?: boolean;
 
     /**
      * Tuning for the preflight response itself.
@@ -64,7 +81,7 @@ export type Options = {
          *
          * @default 204
          */
-        statusCode?: number;
+        status?: number;
     };
 };
 
@@ -74,9 +91,10 @@ export type ResolvedOptions = {
     allowHeaders: CorsListOption;
     exposeHeaders: CorsListOption;
     credentials: boolean;
-    maxAge: string | false;
+    maxAge: CorsMaxAgeOption;
+    preflightContinue: boolean;
     preflight: {
-        statusCode: number;
+        status: number;
     };
 };
 

--- a/packages/cors/src/types.ts
+++ b/packages/cors/src/types.ts
@@ -1,0 +1,83 @@
+export type CorsOriginOption = '*' |
+    'null' |
+    (string | RegExp)[] |
+    ((origin: string) => boolean);
+
+export type CorsListOption = '*' | string[];
+
+export type Options = {
+    /**
+     * Determines the value of the `access-control-allow-origin` response header.
+     * - `'*'` allows all origins.
+     * - `'null'` allows opaque (sandboxed) origins.
+     * - An array of strings / RegExps is matched against the request `Origin`.
+     * - A function receives the request `Origin` and returns `true` if allowed.
+     *
+     * @default '*'
+     */
+    origin?: CorsOriginOption;
+
+    /**
+     * Value of `access-control-allow-methods` for preflight responses.
+     *
+     * @default '*'
+     */
+    methods?: CorsListOption;
+
+    /**
+     * Value of `access-control-allow-headers` for preflight responses.
+     * When `'*'` or empty, mirrors the request's `access-control-request-headers`.
+     *
+     * @default '*'
+     */
+    allowHeaders?: CorsListOption;
+
+    /**
+     * Value of `access-control-expose-headers` on actual responses.
+     *
+     * @default '*'
+     */
+    exposeHeaders?: CorsListOption;
+
+    /**
+     * Sets `access-control-allow-credentials: true` when enabled.
+     * When credentials are allowed, none of `origin`, `methods`, `exposeHeaders`,
+     * `allowHeaders` may be `'*'` — browsers will reject the response.
+     *
+     * @default false
+     */
+    credentials?: boolean;
+
+    /**
+     * Value of `access-control-max-age` for preflight responses.
+     *
+     * @default false
+     */
+    maxAge?: string | false;
+
+    /**
+     * Tuning for the preflight response itself.
+     */
+    preflight?: {
+        /**
+         * Status code returned for preflight (`OPTIONS`) requests.
+         *
+         * @default 204
+         */
+        statusCode?: number;
+    };
+};
+
+export type ResolvedOptions = {
+    origin: CorsOriginOption;
+    methods: CorsListOption;
+    allowHeaders: CorsListOption;
+    exposeHeaders: CorsListOption;
+    credentials: boolean;
+    maxAge: string | false;
+    preflight: {
+        statusCode: number;
+    };
+};
+
+export type CorsHeaderEntry = readonly [name: string, value: string];

--- a/packages/cors/src/utils.ts
+++ b/packages/cors/src/utils.ts
@@ -1,0 +1,171 @@
+import type { IRoutupEvent } from 'routup';
+import { appendResponseHeader, getRequestHeader } from 'routup';
+import type {
+    CorsHeaderEntry,
+    Options,
+    ResolvedOptions,
+} from './types';
+
+export function resolveOptions(options: Options = {}): ResolvedOptions {
+    return {
+        origin: options.origin ?? '*',
+        methods: options.methods ?? '*',
+        allowHeaders: options.allowHeaders ?? '*',
+        exposeHeaders: options.exposeHeaders ?? '*',
+        credentials: options.credentials ?? false,
+        maxAge: options.maxAge ?? false,
+        preflight: { statusCode: options.preflight?.statusCode ?? 204 },
+    };
+}
+
+export function isPreflightRequest(event: IRoutupEvent): boolean {
+    if (event.method !== 'OPTIONS') {
+        return false;
+    }
+
+    const origin = getRequestHeader(event, 'origin');
+    const acrm = getRequestHeader(event, 'access-control-request-method');
+
+    return !!origin && !!acrm;
+}
+
+export function isCorsOriginAllowed(
+    origin: string | null | undefined,
+    options: Options,
+): boolean {
+    const { origin: originOption } = options;
+
+    if (!origin) {
+        return false;
+    }
+
+    if (!originOption || originOption === '*') {
+        return true;
+    }
+
+    if (typeof originOption === 'function') {
+        return originOption(origin);
+    }
+
+    if (Array.isArray(originOption)) {
+        return originOption.some((entry) => {
+            if (entry instanceof RegExp) {
+                return entry.test(origin);
+            }
+
+            return origin === entry;
+        });
+    }
+
+    return originOption === origin;
+}
+
+export function createOriginHeaders(
+    event: IRoutupEvent,
+    options: Options,
+): CorsHeaderEntry[] {
+    const { origin: originOption } = options;
+    const origin = getRequestHeader(event, 'origin');
+
+    if (!originOption || originOption === '*') {
+        return [['access-control-allow-origin', '*']];
+    }
+
+    if (originOption === 'null') {
+        return [
+            ['access-control-allow-origin', 'null'],
+            ['vary', 'origin'],
+        ];
+    }
+
+    if (isCorsOriginAllowed(origin, options)) {
+        return [
+            ['access-control-allow-origin', origin as string],
+            ['vary', 'origin'],
+        ];
+    }
+
+    return [];
+}
+
+export function createMethodsHeaders(options: Options): CorsHeaderEntry[] {
+    const { methods } = options;
+
+    if (!methods) {
+        return [];
+    }
+
+    if (methods === '*') {
+        return [['access-control-allow-methods', '*']];
+    }
+
+    if (methods.length === 0) {
+        return [];
+    }
+
+    return [['access-control-allow-methods', methods.join(',')]];
+}
+
+export function createCredentialsHeaders(options: Options): CorsHeaderEntry[] {
+    return options.credentials ?
+        [['access-control-allow-credentials', 'true']] :
+        [];
+}
+
+export function createAllowHeaderHeaders(
+    event: IRoutupEvent,
+    options: Options,
+): CorsHeaderEntry[] {
+    const { allowHeaders } = options;
+
+    if (!allowHeaders || allowHeaders === '*' || allowHeaders.length === 0) {
+        const requested = getRequestHeader(event, 'access-control-request-headers');
+        if (!requested) {
+            return [];
+        }
+
+        return [
+            ['access-control-allow-headers', requested],
+            ['vary', 'access-control-request-headers'],
+        ];
+    }
+
+    return [
+        ['access-control-allow-headers', allowHeaders.join(',')],
+        ['vary', 'access-control-request-headers'],
+    ];
+}
+
+export function createExposeHeaders(options: Options): CorsHeaderEntry[] {
+    const { exposeHeaders } = options;
+
+    if (!exposeHeaders) {
+        return [];
+    }
+
+    if (exposeHeaders === '*') {
+        return [['access-control-expose-headers', '*']];
+    }
+
+    if (exposeHeaders.length === 0) {
+        return [];
+    }
+
+    return [['access-control-expose-headers', exposeHeaders.join(',')]];
+}
+
+export function createMaxAgeHeader(options: Options): CorsHeaderEntry[] {
+    return options.maxAge ?
+        [['access-control-max-age', options.maxAge]] :
+        [];
+}
+
+export function applyHeaders(event: IRoutupEvent, entries: CorsHeaderEntry[]): void {
+    for (const [name, value] of entries) {
+        if (name === 'vary') {
+            appendResponseHeader(event, name, value);
+        } else {
+            event.response.headers.set(name, value);
+        }
+    }
+}

--- a/packages/cors/src/utils.ts
+++ b/packages/cors/src/utils.ts
@@ -50,7 +50,10 @@ export function isCorsOriginAllowed(
     if (Array.isArray(originOption)) {
         return originOption.some((entry) => {
             if (entry instanceof RegExp) {
-                return entry.test(origin);
+                const stateless = entry.global || entry.sticky ?
+                    new RegExp(entry.source, entry.flags.replace(/[gy]/g, '')) :
+                    entry;
+                return stateless.test(origin);
             }
 
             return origin === entry;

--- a/packages/cors/src/utils.ts
+++ b/packages/cors/src/utils.ts
@@ -14,7 +14,8 @@ export function resolveOptions(options: Options = {}): ResolvedOptions {
         exposeHeaders: options.exposeHeaders ?? '*',
         credentials: options.credentials ?? false,
         maxAge: options.maxAge ?? false,
-        preflight: { statusCode: options.preflight?.statusCode ?? 204 },
+        preflightContinue: options.preflightContinue ?? false,
+        preflight: { status: options.preflight?.status ?? 204 },
     };
 }
 
@@ -29,17 +30,28 @@ export function isPreflightRequest(event: IRoutupEvent): boolean {
     return !!origin && !!acrm;
 }
 
+function testRegExp(pattern: RegExp, origin: string): boolean {
+    const stateless = pattern.global || pattern.sticky ?
+        new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, '')) :
+        pattern;
+    return stateless.test(origin);
+}
+
 export function isCorsOriginAllowed(
     origin: string | null | undefined,
     options: Options,
 ): boolean {
     const { origin: originOption } = options;
 
+    if (originOption === false) {
+        return false;
+    }
+
     if (!origin) {
         return false;
     }
 
-    if (!originOption || originOption === '*') {
+    if (originOption === undefined || originOption === '*' || originOption === true) {
         return true;
     }
 
@@ -47,13 +59,14 @@ export function isCorsOriginAllowed(
         return originOption(origin);
     }
 
+    if (originOption instanceof RegExp) {
+        return testRegExp(originOption, origin);
+    }
+
     if (Array.isArray(originOption)) {
         return originOption.some((entry) => {
             if (entry instanceof RegExp) {
-                const stateless = entry.global || entry.sticky ?
-                    new RegExp(entry.source, entry.flags.replace(/[gy]/g, '')) :
-                    entry;
-                return stateless.test(origin);
+                return testRegExp(entry, origin);
             }
 
             return origin === entry;
@@ -68,22 +81,37 @@ export function createOriginHeaders(
     options: Options,
 ): CorsHeaderEntry[] {
     const { origin: originOption } = options;
-    const origin = getRequestHeader(event, 'origin');
 
-    if (!originOption || originOption === '*') {
+    if (originOption === false) {
+        return [];
+    }
+
+    if (originOption === undefined || originOption === '*') {
         return [['access-control-allow-origin', '*']];
     }
 
-    if (originOption === 'null') {
+    const requestOrigin = getRequestHeader(event, 'origin');
+
+    if (originOption === true) {
+        if (!requestOrigin) {
+            return [];
+        }
         return [
-            ['access-control-allow-origin', 'null'],
+            ['access-control-allow-origin', requestOrigin],
             ['vary', 'origin'],
         ];
     }
 
-    if (isCorsOriginAllowed(origin, options)) {
+    if (typeof originOption === 'string') {
         return [
-            ['access-control-allow-origin', origin as string],
+            ['access-control-allow-origin', originOption],
+            ['vary', 'origin'],
+        ];
+    }
+
+    if (isCorsOriginAllowed(requestOrigin, options)) {
+        return [
+            ['access-control-allow-origin', requestOrigin as string],
             ['vary', 'origin'],
         ];
     }
@@ -158,9 +186,12 @@ export function createExposeHeaders(options: Options): CorsHeaderEntry[] {
 }
 
 export function createMaxAgeHeader(options: Options): CorsHeaderEntry[] {
-    return options.maxAge ?
-        [['access-control-max-age', options.maxAge]] :
-        [];
+    const { maxAge } = options;
+    if (maxAge === false || maxAge === undefined) {
+        return [];
+    }
+
+    return [['access-control-max-age', String(maxAge)]];
 }
 
 export function applyHeaders(event: IRoutupEvent, entries: CorsHeaderEntry[]): void {

--- a/packages/cors/src/utils.ts
+++ b/packages/cors/src/utils.ts
@@ -39,7 +39,7 @@ function testRegExp(pattern: RegExp, origin: string): boolean {
 
 export function isCorsOriginAllowed(
     origin: string | null | undefined,
-    options: Options,
+    options: Options = {},
 ): boolean {
     const { origin: originOption } = options;
 
@@ -78,7 +78,7 @@ export function isCorsOriginAllowed(
 
 export function createOriginHeaders(
     event: IRoutupEvent,
-    options: Options,
+    options: Options = {},
 ): CorsHeaderEntry[] {
     const { origin: originOption } = options;
 
@@ -119,7 +119,7 @@ export function createOriginHeaders(
     return [];
 }
 
-export function createMethodsHeaders(options: Options): CorsHeaderEntry[] {
+export function createMethodsHeaders(options: Options = {}): CorsHeaderEntry[] {
     const { methods } = options;
 
     if (!methods) {
@@ -137,7 +137,7 @@ export function createMethodsHeaders(options: Options): CorsHeaderEntry[] {
     return [['access-control-allow-methods', methods.join(',')]];
 }
 
-export function createCredentialsHeaders(options: Options): CorsHeaderEntry[] {
+export function createCredentialsHeaders(options: Options = {}): CorsHeaderEntry[] {
     return options.credentials ?
         [['access-control-allow-credentials', 'true']] :
         [];
@@ -145,7 +145,7 @@ export function createCredentialsHeaders(options: Options): CorsHeaderEntry[] {
 
 export function createAllowHeaderHeaders(
     event: IRoutupEvent,
-    options: Options,
+    options: Options = {},
 ): CorsHeaderEntry[] {
     const { allowHeaders } = options;
 
@@ -167,7 +167,7 @@ export function createAllowHeaderHeaders(
     ];
 }
 
-export function createExposeHeaders(options: Options): CorsHeaderEntry[] {
+export function createExposeHeaders(options: Options = {}): CorsHeaderEntry[] {
     const { exposeHeaders } = options;
 
     if (!exposeHeaders) {
@@ -185,7 +185,7 @@ export function createExposeHeaders(options: Options): CorsHeaderEntry[] {
     return [['access-control-expose-headers', exposeHeaders.join(',')]];
 }
 
-export function createMaxAgeHeader(options: Options): CorsHeaderEntry[] {
+export function createMaxAgeHeader(options: Options = {}): CorsHeaderEntry[] {
     const { maxAge } = options;
     if (maxAge === false || maxAge === undefined) {
         return [];

--- a/packages/cors/test/unit/module.spec.ts
+++ b/packages/cors/test/unit/module.spec.ts
@@ -1,0 +1,306 @@
+import { 
+    describe, 
+    expect, 
+    it, 
+    vi, 
+} from 'vitest';
+import {
+    Router,
+    defineCoreHandler,
+} from 'routup';
+import {
+    appendCorsHeaders,
+    appendCorsPreflightHeaders,
+    cors,
+    handleCors,
+    isCorsOriginAllowed,
+    isPreflightRequest,
+} from '../../src';
+
+function createTestRequest(url: string, options?: RequestInit): Request {
+    const fullUrl = url.startsWith('http') ? url : `http://localhost${url}`;
+    return new Request(fullUrl, options);
+}
+
+describe('src/module', () => {
+    it('should add wildcard origin headers on a simple request', async () => {
+        const router = new Router();
+        router.use(cors());
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', { headers: { origin: 'http://example.com' } }));
+
+        expect(response.status).toEqual(200);
+        expect(response.headers.get('access-control-allow-origin')).toEqual('*');
+    });
+
+    it('should answer preflight with default 204 + headers', async () => {
+        const router = new Router();
+        router.use(cors());
+        router.post('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+                'access-control-request-headers': 'content-type',
+            },
+        }));
+
+        expect(response.status).toEqual(204);
+        expect(response.headers.get('access-control-allow-origin')).toEqual('*');
+        expect(response.headers.get('access-control-allow-methods')).toEqual('*');
+        expect(response.headers.get('access-control-allow-headers')).toEqual('content-type');
+    });
+
+    it('should override preflight statusCode', async () => {
+        const router = new Router();
+        router.use(cors({ preflight: { statusCode: 200 } }));
+        router.post('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+
+        expect(response.status).toEqual(200);
+    });
+
+    it('should allow origin from string array', async () => {
+        const router = new Router();
+        router.use(cors({ origin: ['http://allowed.test'] }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const allowed = await router.fetch(createTestRequest('/', { headers: { origin: 'http://allowed.test' } }));
+        expect(allowed.headers.get('access-control-allow-origin')).toEqual('http://allowed.test');
+        expect(allowed.headers.get('vary')).toContain('origin');
+
+        const denied = await router.fetch(createTestRequest('/', { headers: { origin: 'http://denied.test' } }));
+        expect(denied.headers.get('access-control-allow-origin')).toBeNull();
+    });
+
+    it('should allow origin from RegExp entry', async () => {
+        const router = new Router();
+        router.use(cors({ origin: [/\.allowed\.test$/] }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', { headers: { origin: 'http://api.allowed.test' } }));
+
+        expect(response.headers.get('access-control-allow-origin'))
+            .toEqual('http://api.allowed.test');
+    });
+
+    it('should allow origin from custom function', async () => {
+        const router = new Router();
+        router.use(cors({ origin: (origin) => origin.endsWith('.example.com') }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', { headers: { origin: 'http://api.example.com' } }));
+
+        expect(response.headers.get('access-control-allow-origin'))
+            .toEqual('http://api.example.com');
+    });
+
+    it('should emit "null" origin when configured', async () => {
+        const router = new Router();
+        router.use(cors({ origin: 'null' }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', { headers: { origin: 'null' } }));
+
+        expect(response.headers.get('access-control-allow-origin')).toEqual('null');
+        expect(response.headers.get('vary')).toContain('origin');
+    });
+
+    it('should emit credentials header and warn on wildcard origin', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        const router = new Router();
+        router.use(cors({ credentials: true }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', { headers: { origin: 'http://example.com' } }));
+
+        expect(response.headers.get('access-control-allow-credentials')).toEqual('true');
+        expect(warn).toHaveBeenCalled();
+
+        warn.mockRestore();
+    });
+
+    it('should not warn for credentials with explicit origin', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        cors({ credentials: true, origin: ['http://example.com'] });
+
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it('should join methods array', async () => {
+        const router = new Router();
+        router.use(cors({ methods: ['GET', 'POST'] }));
+        router.post('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+
+        expect(response.headers.get('access-control-allow-methods')).toEqual('GET,POST');
+    });
+
+    it('should expose listed response headers', async () => {
+        const router = new Router();
+        router.use(cors({ exposeHeaders: ['x-total-count', 'etag'] }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', { headers: { origin: 'http://example.com' } }));
+
+        expect(response.headers.get('access-control-expose-headers'))
+            .toEqual('x-total-count,etag');
+    });
+
+    it('should set max-age on preflight', async () => {
+        const router = new Router();
+        router.use(cors({ maxAge: '600' }));
+        router.post('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+
+        expect(response.headers.get('access-control-max-age')).toEqual('600');
+    });
+
+    it('should preserve both vary values when origin and allowHeaders are concrete', async () => {
+        const router = new Router();
+        router.use(cors({
+            origin: ['http://example.com'],
+            allowHeaders: ['content-type'],
+        }));
+        router.post('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+
+        const vary = response.headers.get('vary') ?? '';
+        expect(vary).toContain('origin');
+        expect(vary).toContain('access-control-request-headers');
+    });
+
+    it('should not produce a preflight response on a non-OPTIONS request', async () => {
+        const router = new Router();
+        router.use(cors());
+        router.post('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'POST',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+
+        expect(response.status).toEqual(200);
+        expect(await response.text()).toEqual('ok');
+    });
+});
+
+describe('helpers', () => {
+    it('isCorsOriginAllowed returns true for wildcard', () => {
+        expect(isCorsOriginAllowed('http://x.test', { origin: '*' })).toBe(true);
+    });
+
+    it('isCorsOriginAllowed returns false for missing origin', () => {
+        expect(isCorsOriginAllowed(null, { origin: ['http://x.test'] })).toBe(false);
+        expect(isCorsOriginAllowed(undefined, { origin: ['http://x.test'] })).toBe(false);
+    });
+
+    it('isCorsOriginAllowed string equality', () => {
+        expect(isCorsOriginAllowed('http://x.test', { origin: ['http://x.test'] })).toBe(true);
+        expect(isCorsOriginAllowed('http://y.test', { origin: ['http://x.test'] })).toBe(false);
+    });
+
+    it('isPreflightRequest returns false without origin or ACRM', async () => {
+        const router = new Router();
+        router.use(defineCoreHandler((event) => {
+            if (isPreflightRequest(event)) {
+                return 'pre';
+            }
+
+            return 'plain';
+        }));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: { origin: 'http://example.com' },
+        }));
+
+        expect(await response.text()).toEqual('plain');
+    });
+
+    it('handleCors returns a response on preflight, undefined otherwise', async () => {
+        const router = new Router();
+        router.use(defineCoreHandler((event) => {
+            const corsResponse = handleCors(event, { origin: '*' });
+            if (corsResponse) {
+                return corsResponse;
+            }
+
+            return 'ok';
+        }));
+
+        const preflight = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+        expect(preflight.status).toEqual(204);
+
+        const plain = await router.fetch(createTestRequest('/', { headers: { origin: 'http://example.com' } }));
+        expect(await plain.text()).toEqual('ok');
+        expect(plain.headers.get('access-control-allow-origin')).toEqual('*');
+    });
+
+    it('appendCorsHeaders / appendCorsPreflightHeaders can be used standalone', async () => {
+        const router = new Router();
+        router.get('/', defineCoreHandler((event) => {
+            appendCorsHeaders(event, { origin: '*', exposeHeaders: ['x-foo'] });
+            return 'ok';
+        }));
+        router.options('/', defineCoreHandler((event) => {
+            appendCorsPreflightHeaders(event, { origin: '*', maxAge: '60' });
+            return new Response(null, {
+                status: 204,
+                headers: event.response.headers,
+            });
+        }));
+
+        const get = await router.fetch(createTestRequest('/', { headers: { origin: 'http://example.com' } }));
+        expect(get.headers.get('access-control-expose-headers')).toEqual('x-foo');
+
+        const opt = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: { origin: 'http://example.com' },
+        }));
+        expect(opt.headers.get('access-control-max-age')).toEqual('60');
+    });
+});

--- a/packages/cors/test/unit/module.spec.ts
+++ b/packages/cors/test/unit/module.spec.ts
@@ -54,9 +54,9 @@ describe('src/module', () => {
         expect(response.headers.get('access-control-allow-headers')).toEqual('content-type');
     });
 
-    it('should override preflight statusCode', async () => {
+    it('should override preflight status', async () => {
         const router = new Router();
-        router.use(cors({ preflight: { statusCode: 200 } }));
+        router.use(cors({ preflight: { status: 200 } }));
         router.post('/', defineCoreHandler(() => 'ok'));
 
         const response = await router.fetch(createTestRequest('/', {
@@ -265,6 +265,122 @@ describe('src/module', () => {
 
         expect(response.status).toEqual(200);
         expect(await response.text()).toEqual('ok');
+    });
+
+    it('should set Content-Length: 0 on preflight (Safari compat)', async () => {
+        const router = new Router();
+        router.use(cors());
+        router.post('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+
+        expect(response.status).toEqual(204);
+        expect(response.headers.get('content-length')).toEqual('0');
+    });
+
+    it('should accept maxAge as number', async () => {
+        const router = new Router();
+        router.use(cors({ maxAge: 600 }));
+        router.post('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+
+        expect(response.headers.get('access-control-max-age')).toEqual('600');
+    });
+});
+
+describe('origin option shapes', () => {
+    it('should emit fixed string origin verbatim', async () => {
+        const router = new Router();
+        router.use(cors({ origin: 'https://app.example.com' }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', { headers: { origin: 'http://other.test' } }));
+
+        expect(response.headers.get('access-control-allow-origin'))
+            .toEqual('https://app.example.com');
+        expect(response.headers.get('vary')).toContain('origin');
+    });
+
+    it('should reflect origin matched by a single RegExp', async () => {
+        const router = new Router();
+        router.use(cors({ origin: /\.example\.com$/ }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const allowed = await router.fetch(createTestRequest('/', { headers: { origin: 'http://api.example.com' } }));
+        expect(allowed.headers.get('access-control-allow-origin'))
+            .toEqual('http://api.example.com');
+
+        const denied = await router.fetch(createTestRequest('/', { headers: { origin: 'http://denied.test' } }));
+        expect(denied.headers.get('access-control-allow-origin')).toBeNull();
+    });
+
+    it('should reflect any request origin when origin=true', async () => {
+        const router = new Router();
+        router.use(cors({ origin: true }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/', { headers: { origin: 'http://anything.test' } }));
+
+        expect(response.headers.get('access-control-allow-origin'))
+            .toEqual('http://anything.test');
+        expect(response.headers.get('vary')).toContain('origin');
+    });
+
+    it('should bypass CORS entirely when origin=false', async () => {
+        const router = new Router();
+        router.use(cors({ origin: false }));
+        router.post('/', defineCoreHandler(() => 'ok'));
+
+        const simple = await router.fetch(createTestRequest('/', {
+            method: 'POST',
+            headers: { origin: 'http://example.com' },
+        }));
+        expect(simple.headers.get('access-control-allow-origin')).toBeNull();
+
+        const preflight = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+        expect(preflight.headers.get('access-control-allow-origin')).toBeNull();
+    });
+});
+
+describe('preflightContinue', () => {
+    it('should call next() instead of sending 204 when set', async () => {
+        const router = new Router();
+        router.use(cors({ preflightContinue: true }));
+        router.options('/', defineCoreHandler((event) => new Response('custom-options', {
+            status: 200,
+            headers: event.response.headers,
+        })));
+
+        const response = await router.fetch(createTestRequest('/', {
+            method: 'OPTIONS',
+            headers: {
+                origin: 'http://example.com',
+                'access-control-request-method': 'POST',
+            },
+        }));
+
+        expect(response.status).toEqual(200);
+        expect(await response.text()).toEqual('custom-options');
+        expect(response.headers.get('access-control-allow-origin')).toEqual('*');
     });
 });
 

--- a/packages/cors/test/unit/module.spec.ts
+++ b/packages/cors/test/unit/module.spec.ts
@@ -119,25 +119,71 @@ describe('src/module', () => {
     it('should emit credentials header and warn on wildcard origin', async () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-        const router = new Router();
-        router.use(cors({ credentials: true }));
-        router.get('/', defineCoreHandler(() => 'ok'));
+        try {
+            const router = new Router();
+            router.use(cors({ credentials: true }));
+            router.get('/', defineCoreHandler(() => 'ok'));
 
-        const response = await router.fetch(createTestRequest('/', { headers: { origin: 'http://example.com' } }));
+            const response = await router.fetch(createTestRequest('/', { headers: { origin: 'http://example.com' } }));
 
-        expect(response.headers.get('access-control-allow-credentials')).toEqual('true');
-        expect(warn).toHaveBeenCalled();
-
-        warn.mockRestore();
+            expect(response.headers.get('access-control-allow-credentials')).toEqual('true');
+            expect(warn).toHaveBeenCalled();
+        } finally {
+            warn.mockRestore();
+        }
     });
 
-    it('should not warn for credentials with explicit origin', () => {
+    it('should not warn for credentials with all wildcard fields tightened', () => {
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-        cors({ credentials: true, origin: ['http://example.com'] });
+        try {
+            const router = new Router();
+            router.use(cors({
+                credentials: true,
+                origin: ['http://example.com'],
+                methods: ['GET'],
+                allowHeaders: ['content-type'],
+                exposeHeaders: ['etag'],
+            }));
 
-        expect(warn).not.toHaveBeenCalled();
-        warn.mockRestore();
+            expect(warn).not.toHaveBeenCalled();
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it('should warn when credentials is combined with wildcard methods / allowHeaders / exposeHeaders', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        try {
+            const router = new Router();
+            router.use(cors({
+                credentials: true,
+                origin: ['http://example.com'],
+            }));
+
+            expect(warn).toHaveBeenCalledOnce();
+            const message = warn.mock.calls[0]?.[0] as string;
+            expect(message).toContain('methods');
+            expect(message).toContain('allowHeaders');
+            expect(message).toContain('exposeHeaders');
+            expect(message).not.toContain('origin,');
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it('should match origins against a global-flagged RegExp deterministically', async () => {
+        const router = new Router();
+        const pattern = /\.allowed\.test$/g;
+        router.use(cors({ origin: [pattern] }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const first = await router.fetch(createTestRequest('/', { headers: { origin: 'http://api.allowed.test' } }));
+        const second = await router.fetch(createTestRequest('/', { headers: { origin: 'http://api.allowed.test' } }));
+
+        expect(first.headers.get('access-control-allow-origin')).toEqual('http://api.allowed.test');
+        expect(second.headers.get('access-control-allow-origin')).toEqual('http://api.allowed.test');
     });
 
     it('should join methods array', async () => {

--- a/packages/cors/test/vitest.config.ts
+++ b/packages/cors/test/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['test/unit/**/*.spec.ts'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.ts'],
+            exclude: ['src/**/*.d.ts'],
+            thresholds: {
+                branches: 58,
+                functions: 77,
+                lines: 73,
+                statements: 73,
+            },
+        },
+    },
+});

--- a/packages/cors/tsconfig.build.json
+++ b/packages/cors/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.build.json",
+
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/cors/tsconfig.json
+++ b/packages/cors/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.json"
+}

--- a/packages/cors/tsdown.config.ts
+++ b/packages/cors/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: 'esm',
+    dts: true,
+    clean: true,
+});

--- a/packages/docs/src/.vitepress/config.mts
+++ b/packages/docs/src/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
             {
                 text: 'Operations',
                 items: [
+                    { text: 'cors', link: '/cors/' },
                     { text: 'rate-limit', link: '/rate-limit/' },
                     { text: 'rate-limit-redis', link: '/rate-limit-redis/' },
                     { text: 'prometheus', link: '/prometheus/' },

--- a/packages/docs/src/.vitepress/theme/components/PluginGrid.vue
+++ b/packages/docs/src/.vitepress/theme/components/PluginGrid.vue
@@ -93,8 +93,8 @@ const categories: PluginCategory[] = [
                 name: '@routup/cors',
                 href: '/cors/',
                 accent: '#22c55e',
-                summary: 'Native CORS — preflight handling and Access-Control-* headers without an Express adapter.',
-                bullets: ['Web-API based (no fromNodeMiddleware)', 'Allow-list strings, RegExps, or predicate fns', 'Preserves multiple Vary values'],
+                summary: 'CORS — preflight handling and Access-Control-* response headers.',
+                bullets: ['Single-string, RegExp, array, or predicate origin', 'preflightContinue + custom preflight status', 'Preserves multiple Vary values'],
             },
             {
                 name: '@routup/rate-limit',

--- a/packages/docs/src/.vitepress/theme/components/PluginGrid.vue
+++ b/packages/docs/src/.vitepress/theme/components/PluginGrid.vue
@@ -87,8 +87,15 @@ const categories: PluginCategory[] = [
     },
     {
         name: 'Operations',
-        summary: 'Throttle, observe, translate.',
+        summary: 'Secure, throttle, observe, translate.',
         plugins: [
+            {
+                name: '@routup/cors',
+                href: '/cors/',
+                accent: '#22c55e',
+                summary: 'Native CORS — preflight handling and Access-Control-* headers without an Express adapter.',
+                bullets: ['Web-API based (no fromNodeMiddleware)', 'Allow-list strings, RegExps, or predicate fns', 'Preserves multiple Vary values'],
+            },
             {
                 name: '@routup/rate-limit',
                 href: '/rate-limit/',

--- a/packages/docs/src/cors/helpers.md
+++ b/packages/docs/src/cors/helpers.md
@@ -1,0 +1,70 @@
+---
+title: CORS — Helpers
+description: Apply CORS headers programmatically — preflight detection, origin checks, header appenders.
+relatedPlugins: []
+---
+
+# Helpers
+
+## `handleCors`
+
+All-in-one helper. Appends the right CORS headers and, on a preflight request, returns a ready-to-send `Response`.
+
+```typescript
+declare function handleCors(
+    event: IRoutupEvent,
+    options: Options,
+): Response | undefined;
+```
+
+```typescript
+router.all('/', defineCoreHandler((event) => {
+    const corsResponse = handleCors(event, { origin: '*' });
+    if (corsResponse) {
+        return corsResponse;
+    }
+
+    return 'ok';
+}));
+```
+
+## `appendCorsHeaders`
+
+Appends the non-preflight CORS headers (`Allow-Origin`, `Allow-Credentials`, `Expose-Headers`).
+
+```typescript
+declare function appendCorsHeaders(
+    event: IRoutupEvent,
+    options: Options,
+): void;
+```
+
+## `appendCorsPreflightHeaders`
+
+Appends the preflight CORS headers (`Allow-Methods`, `Allow-Headers`, `Max-Age`, plus origin/credentials).
+
+```typescript
+declare function appendCorsPreflightHeaders(
+    event: IRoutupEvent,
+    options: Options,
+): void;
+```
+
+## `isPreflightRequest`
+
+Returns `true` for `OPTIONS` requests carrying both an `Origin` header and `Access-Control-Request-Method`.
+
+```typescript
+declare function isPreflightRequest(event: IRoutupEvent): boolean;
+```
+
+## `isCorsOriginAllowed`
+
+Pure check against the `origin` option — useful when you need to make a CORS-related decision (e.g. logging, custom redirect) outside the plugin itself.
+
+```typescript
+declare function isCorsOriginAllowed(
+    origin: string | null | undefined,
+    options: Options,
+): boolean;
+```

--- a/packages/docs/src/cors/helpers.md
+++ b/packages/docs/src/cors/helpers.md
@@ -30,7 +30,7 @@ router.all('/', defineCoreHandler((event) => {
 
 ## `appendCorsHeaders`
 
-Appends the non-preflight CORS headers (`Allow-Origin`, `Allow-Credentials`, `Expose-Headers`).
+Appends the non-preflight CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`, `Access-Control-Expose-Headers`).
 
 ```typescript
 declare function appendCorsHeaders(
@@ -41,7 +41,7 @@ declare function appendCorsHeaders(
 
 ## `appendCorsPreflightHeaders`
 
-Appends the preflight CORS headers (`Allow-Methods`, `Allow-Headers`, `Max-Age`, plus origin/credentials).
+Appends the preflight CORS headers (`Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Max-Age`, plus origin/credentials).
 
 ```typescript
 declare function appendCorsPreflightHeaders(

--- a/packages/docs/src/cors/index.md
+++ b/packages/docs/src/cors/index.md
@@ -1,12 +1,12 @@
 ---
 title: CORS
-description: Handle preflight requests and add Access-Control-* response headers natively, without an Express middleware adapter.
+description: Handle preflight requests and add Access-Control-* response headers.
 relatedPlugins: [body, cookie]
 ---
 
 # @routup/cors
 
-Native CORS plugin for routup — built on Web Standard `Request` / `Response` (no `fromNodeMiddleware` adapter). Handles preflight (`OPTIONS`) requests and decorates ordinary responses with the right `Access-Control-*` headers.
+CORS plugin for routup — built on Web Standard `Request` / `Response`. Handles preflight (`OPTIONS`) requests and decorates ordinary responses with the right `Access-Control-*` headers.
 
 ## Installation
 
@@ -38,7 +38,6 @@ The plugin short-circuits preflight requests with a `204` and adds the right `Ac
 ## When to use it
 
 - Your API is consumed from a browser on a different origin.
-- You want first-class CORS handling without going through the Express `cors` package via `fromNodeMiddleware`.
 - You need precise control over preflight: status code, allow-listed methods/headers, max-age, credentials.
 
 ## Options at a glance

--- a/packages/docs/src/cors/index.md
+++ b/packages/docs/src/cors/index.md
@@ -49,7 +49,7 @@ The plugin short-circuits preflight requests with a `204` and adds the right `Ac
 | `methods` | `'*'` | Allowed methods on preflight. Pass `['GET','POST']` for explicit lists. |
 | `allowHeaders` | `'*'` | Mirrors `Access-Control-Request-Headers` when `'*'` or empty. |
 | `exposeHeaders` | `'*'` | Headers visible to the browser via `getResponseHeader`. |
-| `credentials` | `false` | Enable `Allow-Credentials: true`. Forbids any `'*'` origin/method/header — browsers will reject. |
+| `credentials` | `false` | Enable `Access-Control-Allow-Credentials: true`. Forbids any `'*'` origin/method/header — browsers will reject. |
 | `maxAge` | `false` | Cache duration for preflight, in seconds. |
 | `preflight.statusCode` | `204` | Override if a downstream client doesn't tolerate 204. |
 

--- a/packages/docs/src/cors/index.md
+++ b/packages/docs/src/cors/index.md
@@ -45,13 +45,14 @@ The plugin short-circuits preflight requests with a `204` and adds the right `Ac
 
 | Option | Default | Notes |
 |---|---|---|
-| `origin` | `'*'` | Wildcard, `'null'`, allow-list of strings/RegExps, or a custom predicate. |
+| `origin` | `'*'` | `true` reflects the request origin (credentials-friendly); `false` skips CORS entirely. Strings (`'*'`, `'null'`, `'https://app.example.com'`), `RegExp`, allow-list arrays, or custom predicates also supported. |
 | `methods` | `'*'` | Allowed methods on preflight. Pass `['GET','POST']` for explicit lists. |
 | `allowHeaders` | `'*'` | Mirrors `Access-Control-Request-Headers` when `'*'` or empty. |
 | `exposeHeaders` | `'*'` | Headers visible to the browser via `getResponseHeader`. |
 | `credentials` | `false` | Enable `Access-Control-Allow-Credentials: true`. Forbids any `'*'` origin/method/header — browsers will reject. |
-| `maxAge` | `false` | Cache duration for preflight, in seconds. |
-| `preflight.statusCode` | `204` | Override if a downstream client doesn't tolerate 204. |
+| `maxAge` | `false` | Cache duration for preflight, in seconds. Accepts `string` or `number`. |
+| `preflightContinue` | `false` | When `true`, sets preflight headers and forwards to your own `OPTIONS` handler instead of returning 204. |
+| `preflight.status` | `204` | Override if a downstream client doesn't tolerate 204. Preflight responses also set `Content-Length: 0` (Safari compat). |
 
 ## Common patterns
 

--- a/packages/docs/src/cors/index.md
+++ b/packages/docs/src/cors/index.md
@@ -1,0 +1,89 @@
+---
+title: CORS
+description: Handle preflight requests and add Access-Control-* response headers natively, without an Express middleware adapter.
+relatedPlugins: [body, cookie]
+---
+
+# @routup/cors
+
+Native CORS plugin for routup — built on Web Standard `Request` / `Response` (no `fromNodeMiddleware` adapter). Handles preflight (`OPTIONS`) requests and decorates ordinary responses with the right `Access-Control-*` headers.
+
+## Installation
+
+```bash
+npm install @routup/cors
+```
+
+## Quick start
+
+```typescript
+import { Router, defineCoreHandler, serve } from 'routup';
+import { cors } from '@routup/cors';
+
+const router = new Router();
+
+router.use(cors({
+    origin: ['https://app.example.com'],
+    credentials: true,
+    allowHeaders: ['content-type', 'authorization'],
+}));
+
+router.get('/', defineCoreHandler(() => 'ok'));
+
+serve(router, { port: 3000 });
+```
+
+The plugin short-circuits preflight requests with a `204` and adds the right `Access-Control-Allow-*` headers to non-preflight responses.
+
+## When to use it
+
+- Your API is consumed from a browser on a different origin.
+- You want first-class CORS handling without going through the Express `cors` package via `fromNodeMiddleware`.
+- You need precise control over preflight: status code, allow-listed methods/headers, max-age, credentials.
+
+## Options at a glance
+
+| Option | Default | Notes |
+|---|---|---|
+| `origin` | `'*'` | Wildcard, `'null'`, allow-list of strings/RegExps, or a custom predicate. |
+| `methods` | `'*'` | Allowed methods on preflight. Pass `['GET','POST']` for explicit lists. |
+| `allowHeaders` | `'*'` | Mirrors `Access-Control-Request-Headers` when `'*'` or empty. |
+| `exposeHeaders` | `'*'` | Headers visible to the browser via `getResponseHeader`. |
+| `credentials` | `false` | Enable `Allow-Credentials: true`. Forbids any `'*'` origin/method/header — browsers will reject. |
+| `maxAge` | `false` | Cache duration for preflight, in seconds. |
+| `preflight.statusCode` | `204` | Override if a downstream client doesn't tolerate 204. |
+
+## Common patterns
+
+### Allow-list multiple environments
+
+```typescript
+router.use(cors({
+    origin: [
+        'https://app.example.com',
+        /\.staging\.example\.com$/,
+    ],
+    credentials: true,
+}));
+```
+
+### Decorate a single route
+
+When you don't want CORS globally:
+
+```typescript
+import { handleCors } from '@routup/cors';
+
+router.all('/api/public', defineCoreHandler((event) => {
+    const corsResponse = handleCors(event, { origin: '*' });
+    if (corsResponse) {
+        return corsResponse;
+    }
+
+    return loadPayload();
+}));
+```
+
+## See also
+
+- [Helpers](./helpers) — `handleCors`, `appendCorsHeaders`, `isPreflightRequest`, `isCorsOriginAllowed`


### PR DESCRIPTION
Native CORS plugin ported from h3, replacing the typical fromNodeMiddleware(cors()) integration. Handles preflight (OPTIONS) short-circuiting and Access-Control-* headers via routup's web-API helpers — no Express adapter required.

Notable differences from h3:
- header tuples instead of Record<string,string>, so concrete origin + concrete allowHeaders preserves both Vary entries (h3 loses one)
- credentials-with-wildcard warning fires once at install, not per call
- handleCors returns Response | undefined for cleaner routup ergonomics

Adds .agents/references/h3.md tracking source paths and version snapshot so future syncs are mechanical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native CORS plugin to the monorepo, providing preflight support and Access-Control header configuration for cross-origin requests.

* **Documentation**
  * Added comprehensive documentation for the new CORS plugin, including installation, usage, configuration options, and helper utilities.
  * Updated plugin guides and references to include the new CORS functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->