### PR TITLE
feat(logger): add @routup/logger package

### DIFF
--- a/.agents/references/morgan.md
+++ b/.agents/references/morgan.md
@@ -1,0 +1,102 @@
+---
+name: morgan reference
+description: Mapping between morgan's HTTP request logger and @routup/logger — what was kept, what was replaced, and how to keep them in sync.
+type: reference
+---
+
+# morgan Reference
+
+[morgan](https://github.com/expressjs/morgan) is the de-facto Express request logger. `@routup/logger` ports its token + format DSL to routup's web-API model, replacing the typical `fromNodeMiddleware(morgan('tiny'))` integration with a native handler.
+
+Repo: <https://github.com/expressjs/morgan> — the entire library lives in `index.js` (~552 lines).
+
+## Version snapshot (as of 2026-05-06)
+
+| | Version | Source |
+|---|---|---|
+| `morgan` (npm) | `1.10.1` | `index.js` (commit `203c758`) |
+
+Bump the snapshot whenever you sync. Morgan moves slowly — most changes are dependency bumps, not feature work.
+
+## Code mapping (morgan → @routup/logger)
+
+### Public API
+
+| morgan | `@routup/logger` | Notes |
+|---|---|---|
+| `morgan(format, options)` middleware | `logger(format, options)` returning `CoreHandler` | **Not a routup `Plugin`** — see [Why a handler not a plugin](#why-a-handler-not-a-plugin). Same overload shape (`logger(opts)` or `logger(format, opts)`). |
+| `morgan.compile(format)` | `compile(format)` (`src/compile.ts`) | Replaces morgan's `new Function(...)` JIT with a static piece-array walker — safer, CSP-friendly, debuggable. |
+| `morgan.format(name, fmt)` | _(no global registry — pass via `options.format`)_ | Routup port keeps the preset map (`formatStrings`) immutable and exposes `resolveFormat()` for resolution. |
+| `morgan.token(name, fn)` | `options.tokens` (per-instance) or extend `defaultTokens` | Tokens are merged on top of built-ins on each `logger()` call. |
+| `options.skip(req, res)` | `options.skip(event, response)` | `event` is `IRoutupEvent`; `response` may be `undefined` (immediate mode). |
+| `options.stream.write` | `options.write(line)` | Plain function instead of stream-shaped object. |
+| `options.immediate` | `options.immediate` | Same — emits at request start, with `:status` / `:response-time` rendering as `-`. |
+| `options.buffer` | _(dropped)_ | Already deprecated in morgan. |
+
+### Built-in tokens
+
+| morgan token | `@routup/logger` token | Notes |
+|---|---|---|
+| `:url` | `:url` | Renders `pathname + search` — routup uses Web Standard `URL` parsing instead of `req.originalUrl`. |
+| `:method` | `:method` | Identical (`event.method`). |
+| `:status` | `:status` | Reads `response.status` (the actual `Response`, not `res._header`). |
+| `:date` (`web` / `iso` / `clf`) | `:date` (`web` / `iso` / `clf`) | Identical formatter; CLF month table inlined in `src/tokens.ts`. |
+| `:response-time` / `:total-time` | `:response-time` / `:total-time` | Uses `performance.now()` instead of `process.hrtime()`. Stored on `event.store[StartTimeSymbol]` rather than morgan's `req._startAt`. |
+| `:remote-addr` | `:remote-addr` | Delegates to routup's `getRequestIP(event)` (srvx-aware). Morgan walks `req.connection.remoteAddress`. |
+| `:remote-user` | `:remote-user` | Decodes `Authorization: Basic …` via `atob` (no `basic-auth` dep). |
+| `:user-agent` | `:user-agent` | Same. |
+| `:referrer` | `:referrer` | Same — checks both `referer` and the (rare) `referrer` spelling. |
+| `:http-version` | `:http-version` | Reads `request.httpVersion` if present (srvx exposes it on Node), defaults to `'1.1'`. |
+| `:req[name]` | `:req[name]` | Reads from `IRoutupEvent.headers` via `getRequestHeader`. |
+| `:res[name]` | `:res[name]` | Reads from the resolved `Response.headers` (web-API). |
+| `:pid` | `:pid` | Same. |
+
+### Preset formats
+
+| morgan preset | `@routup/logger` preset | Notes |
+|---|---|---|
+| `'combined'` | `'combined'` | Identical format string. |
+| `'common'` | `'common'` | Identical. |
+| `'short'` | `'short'` | Identical. |
+| `'tiny'` | `'tiny'` | Identical. |
+| `'dev'` | `'dev'` (`devFormatter`) | Same status-color palette (red 5xx, yellow 4xx, cyan 3xx, green 2xx). Implemented as a pre-resolved Formatter rather than a compiled-on-demand function. |
+| `'default'` | _(dropped)_ | Was already deprecated in morgan (`use combined format`). |
+
+## Behavioral differences
+
+### Why a handler, not a plugin
+
+Routup's `Plugin` pattern (used by `@routup/cors`, `@routup/cookie`, etc.) installs the plugin's middleware into a **dedicated sub-router** (`packages/.../node_modules/routup/dist/src-*.mjs` `install()` near line 1878). Each router's `event.next()` only walks its own stack — so a plugin-mounted middleware that calls `await event.next()` gets `undefined` (its sub-router has nothing else after it). Sibling routes on the parent router are invisible.
+
+Logging is fundamentally **post-response**: it needs the resolved `Response` (status, headers, content-length) to render `:status` / `:res[*]` / `:response-time`. We get that only when the middleware sits directly on the same router as the route handler. So `logger()` returns a `CoreHandler` and the user mounts it via `router.use(logger())`.
+
+If routup ever adds a "register on parent router" plugin escape hatch, this can be revisited.
+
+### Compiler
+
+morgan: `new Function('tokens, req, res', js)` — JIT-compiles the format string. Faster but CSP-hostile and harder to debug.
+routup: piece-array walker. ~1 microsecond slower per log line, but safe and inspectable. Same regex (`/:([-\w]{2,})(?:\[([^\]]+)\])?/g`).
+
+### Timing
+
+morgan: `process.hrtime()` saved on `req._startAt` and `res._startAt` (the latter populated by `onHeaders(res, ...)`).
+routup: `performance.now()` saved on `event.store[StartTimeSymbol]`. We don't distinguish "headers-sent time" from "finish time" — `:response-time` reflects the time from request start to log emission. For routup the difference is rarely meaningful since dispatch, header building, and body resolution all happen in-process.
+
+### `:remote-user`
+
+morgan: uses the `basic-auth` package (regex + buffer decoding).
+routup: inline `atob` decoding of `Authorization: Basic …`. No third-party dep, drops about 200 LoC.
+
+## When to re-sync
+
+Re-pull `index.js` from `expressjs/morgan` whenever:
+1. A new `1.x` release ships (rare — morgan is in maintenance mode).
+2. Anyone files a missing-token issue against `@routup/logger` — morgan probably has the token already.
+3. `basic-auth` or another transitive dep has a CVE that affected our `:remote-user` parity.
+
+After syncing, update the version snapshot above with the commit SHA, and run:
+
+```bash
+npx nx run @routup/logger:test
+npx nx run @routup/logger:build
+```

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -73,4 +73,4 @@ Layer 2 (adapters):     rate-limit-redis, swagger-ui
 Layer 1 (standalone):   assets, body, cookie, decorators, i18n, logger, prometheus, query, rate-limit
 ```
 
-All packages peer-depend on `routup@^4.0.1`.
+All packages peer-depend on `routup@^5.0.0`.

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -11,6 +11,7 @@ plugins/
 │   ├── cookie/         # Cookie read/write
 │   ├── decorators/     # Class/method/parameter decorators (also exports ./preset for trapi)
 │   ├── i18n/           # Request translation
+│   ├── logger/         # Morgan-compatible request logger (handler factory, not Plugin)
 │   ├── prometheus/     # Metrics collection (prom-client)
 │   ├── query/          # Query string parsing (qs)
 │   ├── rate-limit/     # In-memory rate limiting
@@ -55,6 +56,7 @@ packages/[name]/
 | `cookie` | `@routup/cookie` | Read/serialize cookies | `cookie` |
 | `decorators` | `@routup/decorators` | Route decorators + `./preset` subpath (the `@trapi/metadata` preset for `@D*`) | `@routup/body`, `@routup/cookie`, `@routup/query`; optional peer `@trapi/metadata` |
 | `i18n` | `@routup/i18n` | Request translations | — |
+| `logger` | `@routup/logger` | Request logger ported from morgan; **handler factory**, not a Plugin | — |
 | `prometheus` | `@routup/prometheus` | Metrics + /metrics endpoint | `prom-client` |
 | `query` | `@routup/query` | Query string parsing | `qs` |
 | `rate-limit` | `@routup/rate-limit` | In-memory rate limiter | — |
@@ -68,7 +70,7 @@ OpenAPI generation is not a routup-owned package — call `@trapi/swagger`'s `ge
 ```
 Layer 3 (composites):   basic
 Layer 2 (adapters):     rate-limit-redis, swagger-ui
-Layer 1 (standalone):   assets, body, cookie, decorators, i18n, prometheus, query, rate-limit
+Layer 1 (standalone):   assets, body, cookie, decorators, i18n, logger, prometheus, query, rate-limit
 ```
 
 All packages peer-depend on `routup@^4.0.1`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ typically http framework functions, which are not integrated in the main package
 | [cookie](packages/cookie)                     | Read and parse request cookies and serialize cookies for the response.                             |
 | [decorators](packages/decorators)             | Create request handlers with class-, method- & parameter-decorators.                               |
 | [i18n](packages/i18n)                         | Provide translations for incoming requests.                                                        |
+| [logger](packages/logger)                     | Morgan-compatible HTTP request logger (native, no `fromNodeMiddleware`).                           |
 | [prometheus](packages/prometheus)             | Collect and serve metrics for prometheus.                                                          |
 | [query](packages/query)                       | Read and parse the query string of the request url.                                                |
 | [rate-limit](packages/rate-limit)             | Rate limit incoming requests.                                                                      |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2335,6 +2335,10 @@
             "resolved": "packages/i18n",
             "link": true
         },
+        "node_modules/@routup/logger": {
+            "resolved": "packages/logger",
+            "link": true
+        },
         "node_modules/@routup/plugins-docs": {
             "resolved": "packages/docs",
             "link": true
@@ -11898,6 +11902,17 @@
             },
             "peerDependencies": {
                 "ilingo": "^5.0.0",
+                "routup": "^5.0.0"
+            }
+        },
+        "packages/logger": {
+            "name": "@routup/logger",
+            "version": "0.0.0",
+            "license": "MIT",
+            "devDependencies": {
+                "routup": "^5.0.0"
+            },
+            "peerDependencies": {
                 "routup": "^5.0.0"
             }
         },

--- a/packages/docs/src/.vitepress/config.mts
+++ b/packages/docs/src/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
             {
                 text: 'Operations',
                 items: [
+                    { text: 'logger', link: '/logger/' },
                     { text: 'rate-limit', link: '/rate-limit/' },
                     { text: 'rate-limit-redis', link: '/rate-limit-redis/' },
                     { text: 'prometheus', link: '/prometheus/' },

--- a/packages/docs/src/.vitepress/theme/components/PluginGrid.vue
+++ b/packages/docs/src/.vitepress/theme/components/PluginGrid.vue
@@ -87,8 +87,15 @@ const categories: PluginCategory[] = [
     },
     {
         name: 'Operations',
-        summary: 'Throttle, observe, translate.',
+        summary: 'Log, throttle, observe, translate.',
         plugins: [
+            {
+                name: '@routup/logger',
+                href: '/logger/',
+                accent: '#f43f5e',
+                summary: 'Morgan-compatible HTTP request logger built on the web-API.',
+                bullets: ['Tiny / short / common / combined / dev presets', 'Custom tokens & formatters', 'Pluggable write target + skip predicate'],
+            },
             {
                 name: '@routup/rate-limit',
                 href: '/rate-limit/',

--- a/packages/docs/src/logger/helpers.md
+++ b/packages/docs/src/logger/helpers.md
@@ -1,0 +1,56 @@
+---
+title: Logger — Helpers
+description: Format compiler, preset resolver, and built-in token map.
+relatedPlugins: []
+---
+
+# Helpers
+
+## `compile`
+
+Compiles a format string into a `Formatter`. Replaces tokens (`:name`, `:name[arg]`) with the matching token's return value, falling back to `-` when a token is missing.
+
+```typescript
+declare function compile(format: string): Formatter;
+```
+
+## `resolveFormat`
+
+Resolves a `format` option into a `Formatter`:
+- a function is returned as-is
+- a known preset name (`'tiny'`, `'short'`, `'common'`, `'combined'`, `'dev'`) returns the preset's compiled formatter
+- any other string is treated as a raw format string and compiled
+- `undefined` / non-string / non-function falls back to `'tiny'`
+
+```typescript
+declare function resolveFormat(format: unknown): Formatter;
+```
+
+## `formatStrings`
+
+Object map of preset name → format string. Use it to build derived formats:
+
+```typescript
+import { compile, formatStrings } from '@routup/logger';
+
+const myFormat = compile(`${formatStrings.tiny} :req[x-trace]`);
+```
+
+## `defaultTokens`
+
+The built-in token map. Spread it into a custom token map to extend rather than replace:
+
+```typescript
+import { defaultTokens } from '@routup/logger';
+
+router.use(logger(':method :url :user', {
+    tokens: {
+        ...defaultTokens,
+        user: (event) => event.store.userId as string | undefined,
+    },
+}));
+```
+
+## `devFormatter`
+
+The colorized `Formatter` used by `format: 'dev'`. Exported in case you want to wrap it with extra information.

--- a/packages/docs/src/logger/helpers.md
+++ b/packages/docs/src/logger/helpers.md
@@ -38,17 +38,23 @@ const myFormat = compile(`${formatStrings.tiny} :req[x-trace]`);
 
 ## `defaultTokens`
 
-The built-in token map. Spread it into a custom token map to extend rather than replace:
+The built-in token map. `logger()` already merges `defaultTokens` under any `options.tokens` you supply, so passing custom tokens **extends** the defaults — no manual spread required:
 
 ```typescript
-import { defaultTokens } from '@routup/logger';
-
 router.use(logger(':method :url :user', {
     tokens: {
-        ...defaultTokens,
         user: (event) => event.store.userId as string | undefined,
     },
 }));
+```
+
+Import `defaultTokens` directly when you call `compile()` yourself or build a `Formatter` outside of `logger()` (where the auto-merge doesn't apply):
+
+```typescript
+import { compile, defaultTokens } from '@routup/logger';
+
+const formatter = compile(':method :url :user');
+const line = formatter({ ...defaultTokens, user: () => 'alice' }, event, response);
 ```
 
 ## `devFormatter`

--- a/packages/docs/src/logger/index.md
+++ b/packages/docs/src/logger/index.md
@@ -1,0 +1,87 @@
+---
+title: Logger
+description: Morgan-compatible HTTP request logger for routup, on top of native web-API helpers.
+relatedPlugins: []
+---
+
+# @routup/logger
+
+A native request logger ported from [morgan](https://github.com/expressjs/morgan). Same token DSL, same preset formats (`tiny`, `short`, `common`, `combined`, `dev`) — but built on routup's `IRoutupEvent` + `Response` so you don't need `fromNodeMiddleware`.
+
+## Installation
+
+```bash
+npm install @routup/logger
+```
+
+## Quick start
+
+```typescript
+import { Router, defineCoreHandler, serve } from 'routup';
+import { logger } from '@routup/logger';
+
+const router = new Router();
+
+router.use(logger('tiny'));
+
+router.get('/', defineCoreHandler(() => 'ok'));
+
+serve(router, { port: 3000 });
+```
+
+The handler logs **after** the response is resolved so `:status`, `:response-time`, and `:res[*]` tokens reflect real values.
+
+## Why a handler, not a plugin
+
+Most routup packages export a `Plugin`. `logger()` instead returns a `CoreHandler` you pass to `router.use(...)`. The reason is structural: a routup `Plugin`'s middleware lives inside a **dedicated sub-router**, and `event.next()` from inside that sub-router walks only the sub-router's stack — it never sees the route handler that produced the response. Logging fundamentally needs the resolved `Response`, so it has to live on the parent router. Same ergonomics (`router.use(...)`), different shape.
+
+## Preset formats
+
+| Name | Format |
+|---|---|
+| `tiny` | `:method :url :status :res[content-length] - :response-time ms` |
+| `short` | `:remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] - :response-time ms` |
+| `common` | Apache common log |
+| `combined` | Apache combined log (adds referrer + user-agent) |
+| `dev` | Status color-coded; tuned for terminals |
+
+```typescript
+router.use(logger('combined'));
+router.use(logger('dev'));
+```
+
+## Custom format string
+
+```typescript
+router.use(logger(':method :url :status :response-time ms'));
+```
+
+## Pluggable write target
+
+```typescript
+router.use(logger('tiny', {
+    write: (line) => myStructuredLogger.info({ msg: line }),
+}));
+```
+
+## Skip predicate
+
+```typescript
+router.use(logger('tiny', {
+    skip: (event) => event.path === '/health',
+}));
+```
+
+## Custom tokens
+
+```typescript
+router.use(logger(':method :url :user', {
+    tokens: {
+        user: (event) => event.store.userId as string | undefined,
+    },
+}));
+```
+
+## See also
+
+- [Helpers](./helpers) — `compile`, `resolveFormat`, `defaultTokens`, `formatStrings`

--- a/packages/logger/LICENSE
+++ b/packages/logger/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-present Peter Placzek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,0 +1,126 @@
+# @routup/logger
+
+[![npm version](https://badge.fury.io/js/@routup%2Flogger.svg)](https://badge.fury.io/js/@routup%2Flogger)
+[![main](https://github.com/Tada5hi/routup/actions/workflows/main.yml/badge.svg)](https://github.com/Tada5hi/routup/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/tada5hi/routup/branch/master/graph/badge.svg?token=CLIA667K6V)](https://codecov.io/gh/tada5hi/routup)
+[![Known Vulnerabilities](https://snyk.io/test/github/Tada5hi/routup/badge.svg)](https://snyk.io/test/github/Tada5hi/routup)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+
+A native HTTP request logger for routup — morgan-compatible token DSL on top of routup's web-API helpers, no `fromNodeMiddleware` adapter.
+
+**Table of Contents**
+
+- [Installation](#installation)
+- [Documentation](#documentation)
+- [Usage](#usage)
+- [Options](#options)
+- [Preset formats](#preset-formats)
+- [Tokens](#tokens)
+- [Custom tokens](#custom-tokens)
+- [License](#license)
+
+## Installation
+
+```bash
+npm install @routup/logger --save
+```
+
+## Documentation
+
+To read the docs, visit [https://routup.net](https://routup.net)
+
+## Usage
+
+`logger()` returns a routup `CoreHandler` — pass it to `router.use(...)`. It logs after the response is resolved so `:status`, `:response-time`, and `:res[*]` tokens see real values.
+
+```typescript
+import { Router, defineCoreHandler, serve } from 'routup';
+import { logger } from '@routup/logger';
+
+const router = new Router();
+
+router.use(logger('tiny'));
+
+router.get('/', defineCoreHandler(() => 'ok'));
+
+serve(router, { port: 3000 });
+```
+
+> Logger is intentionally a handler factory rather than a routup `Plugin`. Routup plugins install into a dedicated sub-router whose `event.next()` only walks that sub-router's stack — sibling routes are invisible. Logging needs the resolved `Response`, so the handler form is the right shape.
+
+## Options
+
+```typescript
+logger(options?: Options);
+logger(format: string | Formatter, options?: Options);
+```
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `format` | `string \| Formatter` | `'tiny'` | Format string (e.g. `':method :url :status'`), preset name (`'tiny' \| 'short' \| 'common' \| 'combined' \| 'dev'`), or a `Formatter` function. |
+| `skip` | `(event, response) => boolean` | — | Skip a request from being logged. |
+| `write` | `(line: string) => void` | `console.log` | Where to write the log line. |
+| `immediate` | `boolean` | `false` | Emit at request start instead of after the response. `:status` / `:response-time` render as `-`. |
+| `tokens` | `Record<string, Token>` | `{}` | Additional tokens merged on top of the built-ins. |
+
+## Preset formats
+
+```text
+combined   :remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"
+common     :remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length]
+short      :remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] - :response-time ms
+tiny       :method :url :status :res[content-length] - :response-time ms
+dev        method url status (color-coded by status range) :response-time ms - :res[content-length]
+```
+
+Pass the preset name directly:
+
+```typescript
+router.use(logger('combined'));
+```
+
+## Tokens
+
+| Token | Renders |
+|---|---|
+| `:method` | HTTP method (`GET`, `POST`, ...) |
+| `:url` | `pathname + search` from the request URL |
+| `:status` | Response status code (`-` if not yet sent in immediate mode) |
+| `:response-time` / `:total-time` | Milliseconds since request start, 3 decimals |
+| `:date[web\|iso\|clf]` | Current time in the requested format (defaults to `web`) |
+| `:remote-addr` | Client IP (via `getRequestIP`) |
+| `:remote-user` | Username from `Authorization: Basic …` |
+| `:user-agent` | `User-Agent` header |
+| `:referrer` | `Referer` / `Referrer` header |
+| `:http-version` | `1.1` unless srvx exposes a richer value |
+| `:req[name]` | Request header by name |
+| `:res[name]` | Response header by name |
+| `:pid` | Process id |
+
+Missing values render as `-`.
+
+## Custom tokens
+
+```typescript
+router.use(logger(':method :url :user', {
+    tokens: {
+        user: (event) => event.store.userId as string | undefined,
+    },
+}));
+```
+
+Or use a `Formatter` directly to bypass the token DSL:
+
+```typescript
+router.use(logger(
+    (_tokens, event, response) => {
+        return `[${event.method}] ${event.path} → ${response?.status ?? '?'}`;
+    },
+));
+```
+
+## License
+
+Made with 💚
+
+Published under [MIT License](./LICENSE).

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -70,7 +70,7 @@ combined   :remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-ver
 common     :remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length]
 short      :remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] - :response-time ms
 tiny       :method :url :status :res[content-length] - :response-time ms
-dev        method url status (color-coded by status range) :response-time ms - :res[content-length]
+dev        :method :url :status (color-coded by status range) :response-time ms - :res[content-length]
 ```
 
 Pass the preset name directly:

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -2,7 +2,7 @@
     "name": "@routup/logger",
     "version": "0.0.0",
     "type": "module",
-    "description": "Request logging plugin for routup.",
+    "description": "HTTP request logger handler for routup, with morgan-compatible tokens and presets.",
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,65 @@
+{
+    "name": "@routup/logger",
+    "version": "0.0.0",
+    "type": "module",
+    "description": "Request logging plugin for routup.",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "types": "./dist/index.d.mts",
+            "import": "./dist/index.mjs"
+        }
+    },
+    "types": "./dist/index.d.mts",
+    "files": [
+        "dist/"
+    ],
+    "scripts": {
+        "build": "npm run build:js && npm run build:types",
+        "build:js": "rimraf ./dist && tsdown",
+        "build:types": "tsc --noEmit -p tsconfig.build.json",
+        "test": "vitest run --config ./test/vitest.config.ts",
+        "test:coverage": "vitest run --config ./test/vitest.config.ts --coverage",
+        "lint": "eslint ./src",
+        "lint:fix": "npm run lint -- --fix"
+    },
+    "author": {
+        "name": "Peter Placzek",
+        "email": "contact@tada5hi.net",
+        "url": "https://github.com/tada5hi"
+    },
+    "license": "MIT",
+    "keywords": [
+        "logger",
+        "logging",
+        "morgan",
+        "request-logger",
+        "access-log",
+        "middleware",
+        "api",
+        "rest",
+        "http",
+        "router",
+        "api-router",
+        "route",
+        "routing"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/routup/plugins.git",
+        "directory": "packages/logger"
+    },
+    "bugs": {
+        "url": "https://github.com/routup/plugins/issues"
+    },
+    "homepage": "https://github.com/routup/plugins#readme",
+    "peerDependencies": {
+        "routup": "^5.0.0"
+    },
+    "devDependencies": {
+        "routup": "^5.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/logger/src/compile.ts
+++ b/packages/logger/src/compile.ts
@@ -1,0 +1,61 @@
+import type { Formatter, TokenMap } from './types';
+
+type Piece =    | { type: 'literal'; value: string } |
+    {
+        type: 'token'; 
+        name: string; 
+        arg?: string 
+    };
+
+const TOKEN_RE = /:([-\w]{2,})(?:\[([^\]]+)\])?/g;
+
+function parse(format: string): Piece[] {
+    const pieces: Piece[] = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    TOKEN_RE.lastIndex = 0;
+    while ((match = TOKEN_RE.exec(format)) !== null) {
+        if (match.index > lastIndex) {
+            pieces.push({ type: 'literal', value: format.slice(lastIndex, match.index) });
+        }
+        pieces.push({
+            type: 'token',
+            name: match[1] as string,
+            arg: match[2],
+        });
+        lastIndex = TOKEN_RE.lastIndex;
+    }
+
+    if (lastIndex < format.length) {
+        pieces.push({ type: 'literal', value: format.slice(lastIndex) });
+    }
+
+    return pieces;
+}
+
+export function compile(format: string): Formatter {
+    if (typeof format !== 'string') {
+        throw new TypeError('argument format must be a string');
+    }
+
+    const pieces = parse(format);
+
+    return (tokens: TokenMap, event, response) => {
+        let out = '';
+        for (const piece of pieces) {
+            if (piece.type === 'literal') {
+                out += piece.value;
+                continue;
+            }
+
+            const token = tokens[piece.name];
+            const value = token ?
+                token(event, response, piece.arg) :
+                undefined;
+            out += value ?? '-';
+        }
+
+        return out;
+    };
+}

--- a/packages/logger/src/formats.ts
+++ b/packages/logger/src/formats.ts
@@ -1,0 +1,60 @@
+import { compile } from './compile';
+import type { Formatter, TokenMap } from './types';
+
+export const formatStrings = {
+    combined: ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"',
+    common: ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length]',
+    short: ':remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] - :response-time ms',
+    tiny: ':method :url :status :res[content-length] - :response-time ms',
+} as const satisfies Record<string, string>;
+
+export type PresetFormatName = keyof typeof formatStrings;
+
+const ANSI_RESET = '\x1b[0m';
+function ansi(code: number, text: string): string {
+    return `\x1b[${code}m${text}${ANSI_RESET}`;
+}
+
+export const devFormatter: Formatter = (tokens: TokenMap, event, response) => {
+    const status = response?.status;
+    let color = 0;
+    if (status) {
+        if (status >= 500) {
+            color = 31;
+        } else if (status >= 400) {
+            color = 33;
+        } else if (status >= 300) {
+            color = 36;
+        } else if (status >= 200) {
+            color = 32;
+        }
+    }
+
+    const method = tokens.method?.(event, response) ?? '-';
+    const url = tokens.url?.(event, response) ?? '-';
+    const statusText = tokens.status?.(event, response) ?? '-';
+    const responseTime = tokens['response-time']?.(event, response) ?? '-';
+    const contentLength = tokens.res?.(event, response, 'content-length') ?? '-';
+
+    return `${method} ${url} ${color ? ansi(color, statusText) : statusText} ${responseTime} ms - ${contentLength}`;
+};
+
+export function resolveFormat(format: unknown): Formatter {
+    if (typeof format === 'function') {
+        return format as Formatter;
+    }
+
+    if (typeof format !== 'string') {
+        return compile(formatStrings.tiny);
+    }
+
+    if (format === 'dev') {
+        return devFormatter;
+    }
+
+    if (format in formatStrings) {
+        return compile(formatStrings[format as PresetFormatName]);
+    }
+
+    return compile(format);
+}

--- a/packages/logger/src/formats.ts
+++ b/packages/logger/src/formats.ts
@@ -52,7 +52,7 @@ export function resolveFormat(format: unknown): Formatter {
         return devFormatter;
     }
 
-    if (format in formatStrings) {
+    if (Object.hasOwn(formatStrings, format)) {
         return compile(formatStrings[format as PresetFormatName]);
     }
 

--- a/packages/logger/src/handler.ts
+++ b/packages/logger/src/handler.ts
@@ -1,0 +1,44 @@
+import { defineCoreHandler } from 'routup';
+import { resolveFormat } from './formats';
+import { StartTimeSymbol, defaultTokens } from './tokens';
+import type { Options, TokenMap } from './types';
+
+export function createHandler(options: Options = {}) {
+    const formatter = resolveFormat(options.format ?? 'tiny');
+    const tokens: TokenMap = {
+        ...defaultTokens,
+        ...(options.tokens ?? {}),
+    };
+    const { skip } = options;
+    const write = options.write ?? ((line) => {
+        // eslint-disable-next-line no-console
+        console.log(line);
+    });
+    const immediate = options.immediate ?? false;
+
+    return defineCoreHandler(async (event) => {
+        (event.store as Record<string | symbol, unknown>)[StartTimeSymbol] = performance.now();
+
+        if (immediate) {
+            if (!skip || !skip(event, undefined)) {
+                const line = formatter(tokens, event, undefined);
+                if (line !== undefined) {
+                    write(line);
+                }
+            }
+
+            return event.next();
+        }
+
+        const response = await event.next();
+
+        if (!skip || !skip(event, response)) {
+            const line = formatter(tokens, event, response);
+            if (line !== undefined) {
+                write(line);
+            }
+        }
+
+        return response;
+    });
+}

--- a/packages/logger/src/handler.ts
+++ b/packages/logger/src/handler.ts
@@ -1,3 +1,4 @@
+import type { IRoutupEvent } from 'routup';
 import { defineCoreHandler } from 'routup';
 import { resolveFormat } from './formats';
 import { StartTimeSymbol, defaultTokens } from './tokens';
@@ -16,29 +17,33 @@ export function createHandler(options: Options = {}) {
     });
     const immediate = options.immediate ?? false;
 
+    const emit = (event: IRoutupEvent, response: Response | undefined): void => {
+        if (skip && skip(event, response)) {
+            return;
+        }
+
+        const line = formatter(tokens, event, response);
+        if (line === undefined) {
+            return;
+        }
+
+        try {
+            write(line);
+        } catch {
+            // swallow log-sink failures — logging must not break the request path
+        }
+    };
+
     return defineCoreHandler(async (event) => {
         (event.store as Record<string | symbol, unknown>)[StartTimeSymbol] = performance.now();
 
         if (immediate) {
-            if (!skip || !skip(event, undefined)) {
-                const line = formatter(tokens, event, undefined);
-                if (line !== undefined) {
-                    write(line);
-                }
-            }
-
+            emit(event, undefined);
             return event.next();
         }
 
         const response = await event.next();
-
-        if (!skip || !skip(event, response)) {
-            const line = formatter(tokens, event, response);
-            if (line !== undefined) {
-                write(line);
-            }
-        }
-
+        emit(event, response);
         return response;
     });
 }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,10 @@
+import { logger } from './module';
+
+export * from './compile';
+export * from './formats';
+export * from './handler';
+export * from './module';
+export * from './tokens';
+export * from './types';
+
+export default logger;

--- a/packages/logger/src/module.ts
+++ b/packages/logger/src/module.ts
@@ -1,0 +1,18 @@
+import { createHandler } from './handler';
+import type { FormatInput, Options } from './types';
+
+export function logger(options?: Options): ReturnType<typeof createHandler>;
+export function logger(format: FormatInput, options?: Options): ReturnType<typeof createHandler>;
+export function logger(
+    formatOrOptions?: FormatInput | Options,
+    maybeOptions?: Options,
+) {
+    let resolved: Options;
+    if (typeof formatOrOptions === 'string' || typeof formatOrOptions === 'function') {
+        resolved = { ...(maybeOptions ?? {}), format: formatOrOptions };
+    } else {
+        resolved = formatOrOptions ?? {};
+    }
+
+    return createHandler(resolved);
+}

--- a/packages/logger/src/tokens.ts
+++ b/packages/logger/src/tokens.ts
@@ -1,0 +1,134 @@
+import { getRequestHeader, getRequestIP } from 'routup';
+import type { Token, TokenMap } from './types';
+
+const CLF_MONTH = [
+    'Jan', 
+    'Feb', 
+    'Mar', 
+    'Apr', 
+    'May', 
+    'Jun',
+    'Jul', 
+    'Aug', 
+    'Sep', 
+    'Oct', 
+    'Nov', 
+    'Dec',
+];
+
+function pad2(n: number): string {
+    return n < 10 ? `0${n}` : `${n}`;
+}
+
+function clfDate(date: Date): string {
+    const day = pad2(date.getUTCDate());
+    const month = CLF_MONTH[date.getUTCMonth()];
+    const year = date.getUTCFullYear();
+    const hh = pad2(date.getUTCHours());
+    const mm = pad2(date.getUTCMinutes());
+    const ss = pad2(date.getUTCSeconds());
+    return `${day}/${month}/${year}:${hh}:${mm}:${ss} +0000`;
+}
+
+const URL_TOKEN: Token = (event) => {
+    const { url } = event.request;
+    try {
+        const parsed = new URL(url);
+        return parsed.pathname + parsed.search;
+    } catch {
+        return url;
+    }
+};
+
+const METHOD_TOKEN: Token = (event) => event.method;
+
+const STATUS_TOKEN: Token = (event, response) => (response ?
+    String(response.status) :
+    undefined);
+
+const DATE_TOKEN: Token = (event, response, format = 'web') => {
+    const date = new Date();
+    switch (format) {
+        case 'clf':
+            return clfDate(date);
+        case 'iso':
+            return date.toISOString();
+        case 'web':
+        default:
+            return date.toUTCString();
+    }
+};
+
+const REFERRER_TOKEN: Token = (event) => getRequestHeader(event, 'referer') ??
+    getRequestHeader(event, 'referrer') ??
+    undefined;
+
+const REMOTE_ADDR_TOKEN: Token = (event) => getRequestIP(event) ?? undefined;
+
+const USER_AGENT_TOKEN: Token = (event) => getRequestHeader(event, 'user-agent') ?? undefined;
+
+const HTTP_VERSION_TOKEN: Token = (event) => {
+    const protocol = (event.request as unknown as { httpVersion?: string }).httpVersion;
+    return protocol ?? '1.1';
+};
+
+const REQ_HEADER_TOKEN: Token = (event, response, field) => {
+    if (!field) {
+        return undefined;
+    }
+
+    return getRequestHeader(event, field) ?? undefined;
+};
+
+const RES_HEADER_TOKEN: Token = (event, response, field) => {
+    if (!response || !field) {
+        return undefined;
+    }
+
+    return response.headers.get(field) ?? undefined;
+};
+
+const RESPONSE_TIME_TOKEN: Token = (event, response, digits = '3') => {
+    const start = (event.store as Record<string | symbol, unknown>)[StartTimeSymbol];
+    if (typeof start !== 'number') {
+        return undefined;
+    }
+
+    const ms = performance.now() - start;
+    return ms.toFixed(Number.parseInt(digits, 10));
+};
+
+const PID_TOKEN: Token = () => String(typeof process !== 'undefined' ? process.pid : 0);
+
+const REMOTE_USER_TOKEN: Token = (event) => {
+    const auth = getRequestHeader(event, 'authorization');
+    if (!auth || !auth.toLowerCase().startsWith('basic ')) {
+        return undefined;
+    }
+    try {
+        const decoded = atob(auth.slice(6).trim());
+        const idx = decoded.indexOf(':');
+        return idx >= 0 ? decoded.slice(0, idx) : decoded;
+    } catch {
+        return undefined;
+    }
+};
+
+export const StartTimeSymbol = Symbol.for('@routup/logger:startTime');
+
+export const defaultTokens: TokenMap = {
+    'url': URL_TOKEN,
+    'method': METHOD_TOKEN,
+    'status': STATUS_TOKEN,
+    'date': DATE_TOKEN,
+    'referrer': REFERRER_TOKEN,
+    'remote-addr': REMOTE_ADDR_TOKEN,
+    'remote-user': REMOTE_USER_TOKEN,
+    'user-agent': USER_AGENT_TOKEN,
+    'http-version': HTTP_VERSION_TOKEN,
+    'req': REQ_HEADER_TOKEN,
+    'res': RES_HEADER_TOKEN,
+    'response-time': RESPONSE_TIME_TOKEN,
+    'total-time': RESPONSE_TIME_TOKEN,
+    'pid': PID_TOKEN,
+};

--- a/packages/logger/src/types.ts
+++ b/packages/logger/src/types.ts
@@ -1,0 +1,60 @@
+import type { IRoutupEvent } from 'routup';
+
+export type Token = (
+    event: IRoutupEvent,
+    response: Response | undefined,
+    arg?: string,
+) => string | undefined;
+
+export type TokenMap = Record<string, Token>;
+
+export type Formatter = (
+    tokens: TokenMap,
+    event: IRoutupEvent,
+    response: Response | undefined,
+) => string | undefined;
+
+export type FormatInput = string | Formatter;
+
+export type SkipFn = (
+    event: IRoutupEvent,
+    response: Response | undefined,
+) => boolean;
+
+export type WriteFn = (line: string) => void;
+
+export type Options = {
+    /**
+     * Format string (e.g. `':method :url :status'`), name of a preset
+     * (`'tiny' | 'short' | 'common' | 'combined' | 'dev'`), or a custom
+     * `Formatter` function.
+     *
+     * @default 'tiny'
+     */
+    format?: FormatInput;
+
+    /**
+     * Skip a request from being logged.
+     */
+    skip?: SkipFn;
+
+    /**
+     * Where to write the log line. Defaults to `console.log`.
+     */
+    write?: WriteFn;
+
+    /**
+     * Log immediately when the request starts instead of after the response is
+     * resolved. The `:status` and `:response-time` tokens render as `-` in this
+     * mode.
+     *
+     * @default false
+     */
+    immediate?: boolean;
+
+    /**
+     * Additional tokens to make available to the formatter. Merged on top of
+     * the built-in tokens.
+     */
+    tokens?: TokenMap;
+};

--- a/packages/logger/test/unit/module.spec.ts
+++ b/packages/logger/test/unit/module.spec.ts
@@ -1,0 +1,316 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+import {
+    Router,
+    defineCoreHandler,
+} from 'routup';
+import {
+    compile,
+    devFormatter,
+    formatStrings,
+    logger,
+    resolveFormat,
+} from '../../src';
+
+function createTestRequest(url: string, options?: RequestInit): Request {
+    const fullUrl = url.startsWith('http') ? url : `http://localhost${url}`;
+    return new Request(fullUrl, options);
+}
+
+describe('plugin', () => {
+    let lines: string[];
+    let write: (line: string) => void;
+
+    beforeEach(() => {
+        lines = [];
+        write = (line) => lines.push(line);
+    });
+
+    it('should log default tiny format after response', async () => {
+        const router = new Router();
+        router.use(logger({ write }));
+        router.get('/items', defineCoreHandler(() => 'ok'));
+
+        const response = await router.fetch(createTestRequest('/items'));
+        expect(response.status).toEqual(200);
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toMatch(/^GET \/items 200 .* - [\d.]+ ms$/);
+    });
+
+    it('should accept a custom format string', async () => {
+        const router = new Router();
+        router.use(logger(':method :status', { write }));
+        router.post('/x', defineCoreHandler(() => new Response('made', { status: 201 })));
+
+        await router.fetch(createTestRequest('/x', { method: 'POST' }));
+
+        expect(lines).toEqual(['POST 201']);
+    });
+
+    it('should accept a custom formatter function', async () => {
+        const router = new Router();
+        router.use(logger(
+            (_tokens, event, response) => `[${event.method}] ${response?.status ?? '-'}`,
+            { write },
+        ));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(lines).toEqual(['[GET] 200']);
+    });
+
+    it('should support skip predicate', async () => {
+        const router = new Router();
+        router.use(logger({
+            write,
+            skip: (event) => event.path === '/health',
+        }));
+        router.get('/health', defineCoreHandler(() => 'pong'));
+        router.get('/api', defineCoreHandler(() => 'data'));
+
+        await router.fetch(createTestRequest('/health'));
+        await router.fetch(createTestRequest('/api'));
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toMatch(/^GET \/api/);
+    });
+
+    it('should support custom tokens', async () => {
+        const router = new Router();
+        router.use(logger(':who', {
+            write,
+            tokens: { who: () => 'agent-007' },
+        }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(lines).toEqual(['agent-007']);
+    });
+
+    it('should log immediately when immediate=true', async () => {
+        const router = new Router();
+        router.use(logger(':method :status', { write, immediate: true }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(lines).toEqual(['GET -']);
+    });
+
+    it('should use console.log when no write fn given', async () => {
+        const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+        const router = new Router();
+        router.use(logger());
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(log).toHaveBeenCalledTimes(1);
+        log.mockRestore();
+    });
+});
+
+describe('resolveFormat / formatStrings', () => {
+    it('should expose tiny / short / common / combined preset strings', () => {
+        expect(formatStrings.tiny).toContain(':method');
+        expect(formatStrings.combined).toContain(':referrer');
+    });
+
+    it('should treat string as preset name when matched', () => {
+        const fn = resolveFormat('tiny');
+        expect(typeof fn).toEqual('function');
+    });
+
+    it('should treat unknown string as raw format', () => {
+        const fn = resolveFormat(':method ::raw');
+        expect(typeof fn).toEqual('function');
+    });
+
+    it('should pass through formatter functions', () => {
+        const fmt = () => 'static';
+        expect(resolveFormat(fmt)).toBe(fmt);
+    });
+
+    it('should default to tiny when given non-string non-fn', () => {
+        const fn = resolveFormat(undefined);
+        expect(typeof fn).toEqual('function');
+    });
+
+    it('should colorize dev format by status', () => {
+        const out200 = devFormatter(
+            {
+                method: () => 'GET', 
+                url: () => '/', 
+                status: () => '200', 
+            },
+            { method: 'GET' } as any,
+            { status: 200, headers: new Headers() } as any,
+        );
+        const out500 = devFormatter(
+            {
+                method: () => 'GET', 
+                url: () => '/', 
+                status: () => '500', 
+            },
+            { method: 'GET' } as any,
+            { status: 500, headers: new Headers() } as any,
+        );
+
+        expect(out200).toContain('\x1b[32m');
+        expect(out500).toContain('\x1b[31m');
+    });
+});
+
+describe('compile', () => {
+    it('should replace tokens in order', () => {
+        const fn = compile(':method | :url');
+        const out = fn(
+            { method: () => 'POST', url: () => '/x' },
+            {} as any,
+            undefined,
+        );
+        expect(out).toEqual('POST | /x');
+    });
+
+    it('should support [arg] tokens', () => {
+        const fn = compile(':res[content-length]');
+        const out = fn(
+            { res: (_e, _r, field) => (field === 'content-length' ? '42' : undefined) },
+            {} as any,
+            undefined,
+        );
+        expect(out).toEqual('42');
+    });
+
+    it('should fall back to "-" when token returns undefined', () => {
+        const fn = compile(':missing :method');
+        const out = fn(
+            { method: () => 'GET' },
+            {} as any,
+            undefined,
+        );
+        expect(out).toEqual('- GET');
+    });
+
+    it('should throw on non-string format', () => {
+        expect(() => compile(123 as unknown as string)).toThrow(TypeError);
+    });
+});
+
+describe('built-in tokens', () => {
+    let lines: string[];
+    let write: (line: string) => void;
+
+    beforeEach(() => {
+        lines = [];
+        write = (line) => lines.push(line);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it(':url renders pathname + search', async () => {
+        const router = new Router();
+        router.use(logger(':url', { write }));
+        router.get('/x', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/x?foo=bar'));
+
+        expect(lines).toEqual(['/x?foo=bar']);
+    });
+
+    it(':status renders the response status', async () => {
+        const router = new Router();
+        router.use(logger(':status', { write }));
+        router.get('/', defineCoreHandler(() => new Response('!', { status: 418 })));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(lines).toEqual(['418']);
+    });
+
+    it(':response-time produces a numeric ms value', async () => {
+        const router = new Router();
+        router.use(logger(':response-time', { write }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toMatch(/^\d+\.\d{3}$/);
+    });
+
+    it(':req[name] renders a request header', async () => {
+        const router = new Router();
+        router.use(logger(':req[x-trace]', { write }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/', { headers: { 'x-trace': 'abc' } }));
+
+        expect(lines).toEqual(['abc']);
+    });
+
+    it(':res[name] renders a response header', async () => {
+        const router = new Router();
+        router.use(logger(':res[x-foo]', { write }));
+        router.get('/', defineCoreHandler(() => new Response('ok', { headers: { 'x-foo': 'bar' } })));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(lines).toEqual(['bar']);
+    });
+
+    it(':user-agent renders the request user-agent', async () => {
+        const router = new Router();
+        router.use(logger(':user-agent', { write }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/', { headers: { 'user-agent': 'curl/8' } }));
+
+        expect(lines).toEqual(['curl/8']);
+    });
+
+    it(':remote-user decodes basic auth', async () => {
+        const router = new Router();
+        router.use(logger(':remote-user', { write }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        const auth = `Basic ${btoa('alice:secret')}`;
+        await router.fetch(createTestRequest('/', { headers: { authorization: auth } }));
+
+        expect(lines).toEqual(['alice']);
+    });
+
+    it(':date renders an ISO timestamp when format=iso', async () => {
+        const router = new Router();
+        router.use(logger(':date[iso]', { write }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it(':date[clf] renders the CLF format', async () => {
+        const router = new Router();
+        router.use(logger(':date[clf]', { write }));
+        router.get('/', defineCoreHandler(() => 'ok'));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toMatch(/^\d{2}\/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\/\d{4}:/);
+    });
+});

--- a/packages/logger/test/unit/module.spec.ts
+++ b/packages/logger/test/unit/module.spec.ts
@@ -23,7 +23,7 @@ function createTestRequest(url: string, options?: RequestInit): Request {
     return new Request(fullUrl, options);
 }
 
-describe('plugin', () => {
+describe('handler', () => {
     let lines: string[];
     let write: (line: string) => void;
 
@@ -144,6 +144,13 @@ describe('resolveFormat / formatStrings', () => {
     it('should default to tiny when given non-string non-fn', () => {
         const fn = resolveFormat(undefined);
         expect(typeof fn).toEqual('function');
+    });
+
+    it('should not match prototype keys like "toString" as a preset', () => {
+        const fn = resolveFormat('toString');
+        // Treated as a raw format string, not a preset; tokens fall back to '-'
+        const out = fn({}, {} as any, undefined);
+        expect(out).toEqual('toString');
     });
 
     it('should colorize dev format by status', () => {

--- a/packages/logger/test/vitest.config.ts
+++ b/packages/logger/test/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['test/unit/**/*.spec.ts'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.ts'],
+            exclude: ['src/**/*.d.ts'],
+            thresholds: {
+                branches: 58,
+                functions: 77,
+                lines: 73,
+                statements: 73,
+            },
+        },
+    },
+});

--- a/packages/logger/tsconfig.build.json
+++ b/packages/logger/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.build.json",
+
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.json"
+}

--- a/packages/logger/tsdown.config.ts
+++ b/packages/logger/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: 'esm',
+    dts: true,
+    clean: true,
+});


### PR DESCRIPTION
Native HTTP request logger ported from morgan, replacing the typical fromNodeMiddleware(morgan('tiny')) integration. Same token DSL and preset formats (tiny, short, common, combined, dev), built on routup's IRoutupEvent + Response.

Notable differences from morgan:
- exposed as a CoreHandler factory (router.use(logger())), not a routup Plugin: plugin sub-routers can't see the resolved Response, which the :status / :response-time / :res[*] tokens need
- compile() uses a piece-array walker instead of new Function(...): same regex, CSP-friendly, debuggable
- timing via performance.now() on event.store, not process.hrtime()
- :remote-user via inline atob() (no basic-auth dep), :remote-addr via routup's getRequestIP

Adds .agents/references/morgan.md tracking source paths and version snapshot for future syncs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced @routup/logger, a Morgan-compatible HTTP request logger enabling detailed logging of incoming requests and responses.

* **Documentation**
  * Added comprehensive documentation including installation, usage examples, preset formats, and custom configuration options.

* **Tests**
  * Added unit test suite for the logger plugin functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->